### PR TITLE
Add the region a player left to OnRegionLeft

### DIFF
--- a/TShockAPI/Hooks/RegionHooks.cs
+++ b/TShockAPI/Hooks/RegionHooks.cs
@@ -47,23 +47,25 @@ namespace TShockAPI.Hooks
 		public class RegionLeftEventArgs
 		{
 			public TSPlayer Player { get; private set; }
+			public Region Region { get; private set; }
 
-			public RegionLeftEventArgs(TSPlayer ply)
+			public RegionLeftEventArgs(TSPlayer ply, Region region)
 			{
 				Player = ply;
+				Region = region;
 			}
 		}
 
 		public delegate void RegionLeftD(RegionLeftEventArgs args);
 		public static event RegionLeftD RegionLeft;
-		public static void OnRegionLeft(TSPlayer player)
+		public static void OnRegionLeft(TSPlayer player, Region region)
 		{
 			if (RegionLeft == null)
 			{
 				return;
 			}
 
-			RegionLeft(new RegionLeftEventArgs(player));
+			RegionLeft(new RegionLeftEventArgs(player, region));
 		}
 
 		public class RegionCreatedEventArgs

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -826,7 +826,7 @@ namespace TShockAPI
 					{
 						if (oldRegion != null)
 						{
-							Hooks.RegionHooks.OnRegionLeft(player);
+							Hooks.RegionHooks.OnRegionLeft(player, oldRegion);
 						}
 
 						if (player.CurrentRegion != null)


### PR DESCRIPTION
This should fix #877 by adding the previous region object to the event fired when a player leaves a region.

Waiting for signoff from @Olink prior to merge, because this is me when building hooks:

![b7e](https://cloud.githubusercontent.com/assets/532647/6540266/224b7ea8-c452-11e4-9ee4-b6f65fc35341.jpg)
