### PR TITLE
Add /permission & methods for adding user permissions

### DIFF
--- a/TShockAPI/Group.cs
+++ b/TShockAPI/Group.cs
@@ -140,7 +140,7 @@ namespace TShockAPI
         /// Checks to see if a group has a specified permission.
         /// </summary>
         /// <param name="permission">The permission to check.</param>
-        /// <returns>Returns true if the user has that permission.</returns>
+        /// <returns>Returns true if the group has that permission.</returns>
 		public virtual bool HasPermission(string permission)
         {
 	        return permissionManager.HasPermission(permission);
@@ -157,9 +157,9 @@ namespace TShockAPI
 
         /// <summary>
         /// Clears the permission list and sets it to the list provided, 
-        /// will parse "!permssion" and add it to the negated permissions.
+        /// will parse negated and never permissions.
         /// </summary>
-        /// <param name="permission"></param>
+        /// <param name="permission">The list of permissions to set.</param>
 		public void SetPermission(List<string> permission)
         {
 			permissionManager.Parse(permission);
@@ -167,9 +167,10 @@ namespace TShockAPI
 
         /// <summary>
         /// Will remove a permission from the respective list,
-        /// where "!permission" will remove a negated permission.
+        /// removing negated and never permissions when prefixed
+		/// with the respective prefixes.
         /// </summary>
-        /// <param name="permission"></param>
+        /// <param name="permission">The permission to remove.</param>
 		public void RemovePermission(string permission)
 		{
 			permissionManager.RemovePermission(permission);

--- a/TShockAPI/PermissionSystem/Permissions.cs
+++ b/TShockAPI/PermissionSystem/Permissions.cs
@@ -73,6 +73,9 @@ namespace TShockAPI.PermissionSystem
 		[Description("User can manage groups.")]
 		public static readonly string managegroup = "tshock.admin.group";
 
+		[Description("User can manage permissions.")]
+		public static readonly string managepermissions = "tshock.admin.permissions";
+
 		[Description("User can manage regions.")]
 		public static readonly string manageregion = "tshock.admin.region";
 


### PR DESCRIPTION
Users now have a permissionManager object, along with an SQL column (Permissions) to store their permissions. Should we add the permission fields Groups have to Users? (I.E. Group.Permissions, Group.TotalPermissions).

The /permission command encases /group addperm, delperm and listperm with support for users as well. I haven't removed the latter as it is still debatable whether we should encase everything on a /permission command or just put in the permission management subcommands into the /user command. The most interesting feature on this is probably the different colors between the permissions an object actually owns (yellow) and the permissions an object inherits from its parent/group.