### PR TITLE
Add FileName to ILog interface. Also fixes some missing XML warnings

### DIFF
--- a/TShockAPI/ILog.cs
+++ b/TShockAPI/ILog.cs
@@ -17,51 +17,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 using System;
+using System.Diagnostics;
 
 namespace TShockAPI
 {
-	/// <summary>
-	/// Flags to define which types of message are logged
-	/// </summary>
-	[Flags]
-	public enum LogLevel
-	{
-		/// <summary>
-		/// No messages will be logged
-		/// </summary>
-		None = 0,
-
-		/// <summary>
-		/// Debug messages will be logged
-		/// </summary>
-		Debug = 1,
-
-		/// <summary>
-		/// Informative messages will be logged
-		/// </summary>
-		Info = 2,
-
-		/// <summary>
-		/// Warning message will be logged
-		/// </summary>
-		Warning = 4,
-
-		/// <summary>
-		/// Error messages will be logged
-		/// </summary>
-		Error = 8,
-
-		/// <summary>
-		/// Data messages will be logged
-		/// </summary>
-		Data = 16,
-
-		/// <summary>
-		/// All messages will be logged
-		/// </summary>
-		All = 31
-	}
-
 	/// <summary>
 	/// Logging interface
 	/// </summary>
@@ -76,7 +35,7 @@ namespace TShockAPI
 		/// Checks whether the log level contains the specified flag.
 		/// </summary>
 		/// <param name="type">The <see cref="LogLevel" /> value to check.</param>
-		bool MayWriteType(LogLevel type);
+		bool MayWriteType(TraceLevel type);
 
 		/// <summary>
 		/// Writes an informative string to the log and to the console.
@@ -161,13 +120,13 @@ namespace TShockAPI
 		/// </summary>
 		/// <param name="message">Message to write</param>
 		/// <param name="level">LogLevel assosciated with the message</param>
-		void Write(string message, LogLevel level);
+		void Write(string message, TraceLevel level);
 
 		/// <summary>
 		/// Writes a debug string to the log file.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		void Debug(String message);
+		void Debug(string message);
 
 		/// <summary>
 		/// Writes a debug string to the log file.

--- a/TShockAPI/ILog.cs
+++ b/TShockAPI/ILog.cs
@@ -20,27 +20,57 @@ using System;
 
 namespace TShockAPI
 {
+	/// <summary>
+	/// Flags to define which types of message are logged
+	/// </summary>
 	[Flags]
 	public enum LogLevel
 	{
+		/// <summary>
+		/// No messages will be logged
+		/// </summary>
 		None = 0,
+
+		/// <summary>
+		/// Debug messages will be logged
+		/// </summary>
 		Debug = 1,
+
+		/// <summary>
+		/// Informative messages will be logged
+		/// </summary>
 		Info = 2,
+
+		/// <summary>
+		/// Warning message will be logged
+		/// </summary>
 		Warning = 4,
+
+		/// <summary>
+		/// Error messages will be logged
+		/// </summary>
 		Error = 8,
+
+		/// <summary>
+		/// Data messages will be logged
+		/// </summary>
 		Data = 16,
+
+		/// <summary>
+		/// All messages will be logged
+		/// </summary>
 		All = 31
 	}
 
-/// <summary>
-/// Logging interface
-/// </summary>
+	/// <summary>
+	/// Logging interface
+	/// </summary>
 	public interface ILog
 	{
 		/// <summary>
-		/// Log name
+		/// Log file name
 		/// </summary>
-		string Name { get; }
+		string FileName { get; set; }
 
 		/// <summary>
 		/// Checks whether the log level contains the specified flag.
@@ -57,7 +87,7 @@ namespace TShockAPI
 		/// <summary>
 		/// Writes an informative string to the log and to the console.
 		/// </summary>
-		/// <param name="message">The format of the message to be written.</param>
+		/// <param name="format">The format of the message to be written.</param>
 		/// <param name="args">The format arguments.</param>
 		void ConsoleInfo(string format, params object[] args);
 
@@ -92,6 +122,7 @@ namespace TShockAPI
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
 		void Error(string message);
+
 		/// <summary>
 		/// Writes an error to the log.
 		/// </summary>

--- a/TShockAPI/Log.cs
+++ b/TShockAPI/Log.cs
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 using System;
+using System.Diagnostics;
 
 namespace TShockAPI
 {
@@ -27,9 +28,9 @@ namespace TShockAPI
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
 		[Obsolete("Please use TShock.Log.Data")]
-		public static void Data(String message)
+		public static void Data(string message)
 		{
-			Write(message, LogLevel.Data);
+			Write(message, TraceLevel.Verbose);
 		}
 
 		/// <summary>
@@ -40,7 +41,7 @@ namespace TShockAPI
 		[Obsolete("Please use TShock.Log.Data")]
 		public static void Data(string format, params object[] args)
 		{
-			Data(String.Format(format, args));
+			Data(string.Format(format, args));
 		}
 
 		/// <summary>
@@ -48,9 +49,9 @@ namespace TShockAPI
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
 		[Obsolete("Please use TShock.Log.Error")]
-		public static void Error(String message)
+		public static void Error(string message)
 		{
-			Write(message, LogLevel.Error);
+			Write(message, TraceLevel.Error);
 		}
 
 		/// <summary>
@@ -61,7 +62,7 @@ namespace TShockAPI
 		[Obsolete("Please use TShock.Log.Error")]
 		public static void Error(string format, params object[] args)
 		{
-			Error(String.Format(format, args));
+			Error(string.Format(format, args));
 		}
 
 		/// <summary>
@@ -69,12 +70,12 @@ namespace TShockAPI
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
 		[Obsolete("Please use TShock.Log.ConsoleError")]
-		public static void ConsoleError(String message)
+		public static void ConsoleError(string message)
 		{
 			Console.ForegroundColor = ConsoleColor.Red;
 			Console.WriteLine(message);
 			Console.ForegroundColor = ConsoleColor.Gray;
-			Write(message, LogLevel.Error);
+			Write(message, TraceLevel.Error);
 		}
 
 		/// <summary>
@@ -85,7 +86,7 @@ namespace TShockAPI
 		[Obsolete("Please use TShock.Log.ConsoleError")]
 		public static void ConsoleError(string format, params object[] args)
 		{
-			ConsoleError(String.Format(format, args));
+			ConsoleError(string.Format(format, args));
 		}
 
 		/// <summary>
@@ -93,9 +94,9 @@ namespace TShockAPI
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
 		[Obsolete("Please use TShock.Log.Warn")]
-		public static void Warn(String message)
+		public static void Warn(string message)
 		{
-			Write(message, LogLevel.Warning);
+			Write(message, TraceLevel.Warning);
 		}
 
 		/// <summary>
@@ -106,7 +107,7 @@ namespace TShockAPI
 		[Obsolete("Please use TShock.Log.Warn")]
 		public static void Warn(string format, params object[] args)
 		{
-			Warn(String.Format(format, args));
+			Warn(string.Format(format, args));
 		}
 
 		/// <summary>
@@ -114,9 +115,9 @@ namespace TShockAPI
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
 		[Obsolete("Please use TShock.Log.Info")]
-		public static void Info(String message)
+		public static void Info(string message)
 		{
-			Write(message, LogLevel.Info);
+			Write(message, TraceLevel.Info);
 		}
 
 		/// <summary>
@@ -127,7 +128,7 @@ namespace TShockAPI
 		[Obsolete("Please use TShock.Log.Info")]
 		public static void Info(string format, params object[] args)
 		{
-			Info(String.Format(format, args));
+			Info(string.Format(format, args));
 		}
 
 		/// <summary>
@@ -135,12 +136,12 @@ namespace TShockAPI
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
 		[Obsolete("Please use TShock.Log.ConsoleInfo")]
-		public static void ConsoleInfo(String message)
+		public static void ConsoleInfo(string message)
 		{
 			Console.ForegroundColor = ConsoleColor.Yellow;
 			Console.WriteLine(message);
 			Console.ForegroundColor = ConsoleColor.Gray;
-			Write(message, LogLevel.Info);
+			Write(message, TraceLevel.Info);
 		}
 
 		/// <summary>
@@ -151,7 +152,7 @@ namespace TShockAPI
 		[Obsolete("Please use TShock.Log.ConsoleInfo")]
 		public static void ConsoleInfo(string format, params object[] args)
 		{
-			ConsoleInfo(String.Format(format, args));
+			ConsoleInfo(string.Format(format, args));
 		}
 
 		/// <summary>
@@ -159,9 +160,9 @@ namespace TShockAPI
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
 		[Obsolete("Please use TShock.Log.Debug")]
-		public static void Debug(String message)
+		public static void Debug(string message)
 		{
-			Write(message, LogLevel.Debug);
+			Write(message, TraceLevel.Verbose);
 		}
 
 		/// <summary>
@@ -172,13 +173,13 @@ namespace TShockAPI
 		[Obsolete("Please use TShock.Log.Debug")]
 		public static void Debug(string format, params object[] args)
 		{
-			Debug(String.Format(format, args));
+			Debug(string.Format(format, args));
 		}
 
 		/// <summary>
 		/// Internal method which writes a message directly to the log file.
 		/// </summary>
-		private static void Write(String message, LogLevel level)
+		private static void Write(string message, TraceLevel level)
 		{
 			TShock.Log.Write(message, level);
 		}

--- a/TShockAPI/SqlLog.cs
+++ b/TShockAPI/SqlLog.cs
@@ -35,7 +35,7 @@ namespace TShockAPI
 
 		public override string ToString()
 		{
-			return String.Format("Message: {0}: {1}: {2}",
+			return string.Format("Message: {0}: {1}: {2}",
 				caller, logLevel.ToString().ToUpper(), message);
 		}
 	}
@@ -51,13 +51,18 @@ namespace TShockAPI
 		private readonly List<LogInfo> _failures = new List<LogInfo>(TShock.Config.RevertToTextLogsOnSqlFailures);
 		private bool _useTextLog;
 
-		public string Name
-		{
-			get { return "SQL Log Writer"; }
-		}
+		public string FileName { get; set; }
 
+		/// <summary>
+		/// Sets the database connection and the initial log level.
+		/// </summary>
+		/// <param name="logLevel"></param>
+		/// <param name="db"></param>
+		/// <param name="textlogFilepath">File path to a backup text log in case the SQL log fails</param>
+		/// <param name="clearTextLog"></param>
 		public SqlLog(LogLevel logLevel, IDbConnection db, string textlogFilepath, bool clearTextLog)
 		{
+			FileName = string.Format("{0}://database", db.GetSqlType());
 			_logLevel = logLevel;
 			_database = db;
 			_backupLog = new TextLog(textlogFilepath, logLevel, clearTextLog);
@@ -72,7 +77,7 @@ namespace TShockAPI
 		/// Writes data to the log file.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void Data(String message)
+		public void Data(string message)
 		{
 			Write(message, LogLevel.Data);
 		}
@@ -84,14 +89,14 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void Data(string format, params object[] args)
 		{
-			Data(String.Format(format, args));
+			Data(string.Format(format, args));
 		}
 
 		/// <summary>
 		/// Writes an error to the log file.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void Error(String message)
+		public void Error(string message)
 		{
 			Write(message, LogLevel.Error);
 		}
@@ -103,14 +108,14 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void Error(string format, params object[] args)
 		{
-			Error(String.Format(format, args));
+			Error(string.Format(format, args));
 		}
 
 		/// <summary>
 		/// Writes an error to the log file.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void ConsoleError(String message)
+		public void ConsoleError(string message)
 		{
 			Console.ForegroundColor = ConsoleColor.Red;
 			Console.WriteLine(message);
@@ -125,14 +130,14 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void ConsoleError(string format, params object[] args)
 		{
-			ConsoleError(String.Format(format, args));
+			ConsoleError(string.Format(format, args));
 		}
 
 		/// <summary>
 		/// Writes a warning to the log file.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void Warn(String message)
+		public void Warn(string message)
 		{
 			Write(message, LogLevel.Warning);
 		}
@@ -144,14 +149,14 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void Warn(string format, params object[] args)
 		{
-			Warn(String.Format(format, args));
+			Warn(string.Format(format, args));
 		}
 
 		/// <summary>
 		/// Writes an informative string to the log file.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void Info(String message)
+		public void Info(string message)
 		{
 			Write(message, LogLevel.Info);
 		}
@@ -163,14 +168,14 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void Info(string format, params object[] args)
 		{
-			Info(String.Format(format, args));
+			Info(string.Format(format, args));
 		}
 
 		/// <summary>
 		/// Writes an informative string to the log file. Also outputs to the console.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void ConsoleInfo(String message)
+		public void ConsoleInfo(string message)
 		{
 			Console.ForegroundColor = ConsoleColor.Yellow;
 			Console.WriteLine(message);
@@ -185,14 +190,14 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void ConsoleInfo(string format, params object[] args)
 		{
-			ConsoleInfo(String.Format(format, args));
+			ConsoleInfo(string.Format(format, args));
 		}
 
 		/// <summary>
 		/// Writes a debug string to the log file.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void Debug(String message)
+		public void Debug(string message)
 		{
 			Write(message, LogLevel.Debug);
 		}
@@ -204,7 +209,7 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void Debug(string format, params object[] args)
 		{
-			Debug(String.Format(format, args));
+			Debug(string.Format(format, args));
 		}
 
 		public void Write(string message, LogLevel level)
@@ -238,7 +243,7 @@ namespace TShockAPI
 				while (_failures.Count > 0 && success)
 				{
 					var info = _failures.First();
-					
+
 					try
 					{
 						_database.Query("INSERT INTO Logs (LogLevel, TimeStamp, Caller, Message) VALUES (@0, @1, @2, @3)",
@@ -251,7 +256,7 @@ namespace TShockAPI
 						{
 							caller = "TShock",
 							logLevel = LogLevel.Error,
-							message = String.Format("SQL Log insert query failed: {0}", ex),
+							message = string.Format("SQL Log insert query failed: {0}", ex),
 							timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)
 						});
 					}
@@ -278,9 +283,9 @@ namespace TShockAPI
 				_useTextLog = true;
 				_backupLog.ConsoleError("SQL Logging disabled due to errors. Reverting to text logging.");
 
-				foreach(var logInfo in _failures)
+				foreach (var logInfo in _failures)
 				{
-					_backupLog.Write(String.Format("SQL log failed at: {0}. {1}", logInfo.timestamp, logInfo),
+					_backupLog.Write(string.Format("SQL log failed at: {0}. {1}", logInfo.timestamp, logInfo),
 						LogLevel.Error);
 				}
 				_failures.Clear();

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -202,15 +202,10 @@ namespace TShockAPI
 					throw new Exception("Invalid storage type");
 				}
 
-#if DEBUG       
-				var level = LogLevel.All;
-#else
-				var level = LogLevel.All & ~LogLevel.Debug;
-#endif
 				if (Config.UseSqlLogs)
-					Log = new SqlLog(level, DB, logFilename, LogClear);
+					Log = new SqlLog(DB, logFilename, LogClear);
 				else
-					Log = new TextLog(logFilename, level, LogClear);
+					Log = new TextLog(logFilename, LogClear);
 
 				if (File.Exists(Path.Combine(SavePath, "tshock.pid")))
 				{

--- a/TShockAPI/TextLog.cs
+++ b/TShockAPI/TextLog.cs
@@ -30,7 +30,6 @@ namespace TShockAPI
 	public class TextLog : ILog, IDisposable
 	{
 		private readonly StreamWriter _logWriter;
-		private readonly LogLevel _logLevel;
 
 		/// <summary>
 		/// File name of the Text log
@@ -41,27 +40,25 @@ namespace TShockAPI
 		/// Creates the log file stream and sets the initial log level.
 		/// </summary>
 		/// <param name="filename">The output filename. This file will be overwritten if 'clear' is set.</param>
-		/// <param name="logLevel">The <see cref="LogLevel" /> value which sets the type of messages to output.</param>
 		/// <param name="clear">Whether or not to clear the log file on initialization.</param>
-		public TextLog(string filename, LogLevel logLevel, bool clear)
+		public TextLog(string filename, bool clear)
 		{
 			FileName = filename;
-			_logLevel = logLevel;
 			_logWriter = new StreamWriter(filename, !clear);
 		}
 
-		public bool MayWriteType(LogLevel type)
+		public bool MayWriteType(TraceLevel type)
 		{
-			return ((_logLevel & type) == type);
+			return type != TraceLevel.Off;
 		}
 
 		/// <summary>
 		/// Writes data to the log file.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void Data(String message)
+		public void Data(string message)
 		{
-			Write(message, LogLevel.Data);
+			Write(message, TraceLevel.Verbose);
 		}
 
 		/// <summary>
@@ -71,16 +68,16 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void Data(string format, params object[] args)
 		{
-			Data(String.Format(format, args));
+			Data(string.Format(format, args));
 		}
 
 		/// <summary>
 		/// Writes an error to the log file.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void Error(String message)
+		public void Error(string message)
 		{
-			Write(message, LogLevel.Error);
+			Write(message, TraceLevel.Error);
 		}
 
 		/// <summary>
@@ -90,19 +87,19 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void Error(string format, params object[] args)
 		{
-			Error(String.Format(format, args));
+			Error(string.Format(format, args));
 		}
 
 		/// <summary>
 		/// Writes an error to the log file.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void ConsoleError(String message)
+		public void ConsoleError(string message)
 		{
 			Console.ForegroundColor = ConsoleColor.Red;
 			Console.WriteLine(message);
 			Console.ForegroundColor = ConsoleColor.Gray;
-			Write(message, LogLevel.Error);
+			Write(message, TraceLevel.Error);
 		}
 
 		/// <summary>
@@ -112,16 +109,16 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void ConsoleError(string format, params object[] args)
 		{
-			ConsoleError(String.Format(format, args));
+			ConsoleError(string.Format(format, args));
 		}
 
 		/// <summary>
 		/// Writes a warning to the log file.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void Warn(String message)
+		public void Warn(string message)
 		{
-			Write(message, LogLevel.Warning);
+			Write(message, TraceLevel.Warning);
 		}
 
 		/// <summary>
@@ -131,16 +128,16 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void Warn(string format, params object[] args)
 		{
-			Warn(String.Format(format, args));
+			Warn(string.Format(format, args));
 		}
 
 		/// <summary>
 		/// Writes an informative string to the log file.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void Info(String message)
+		public void Info(string message)
 		{
-			Write(message, LogLevel.Info);
+			Write(message, TraceLevel.Info);
 		}
 
 		/// <summary>
@@ -150,19 +147,19 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void Info(string format, params object[] args)
 		{
-			Info(String.Format(format, args));
+			Info(string.Format(format, args));
 		}
 
 		/// <summary>
 		/// Writes an informative string to the log file. Also outputs to the console.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void ConsoleInfo(String message)
+		public void ConsoleInfo(string message)
 		{
 			Console.ForegroundColor = ConsoleColor.Yellow;
 			Console.WriteLine(message);
 			Console.ForegroundColor = ConsoleColor.Gray;
-			Write(message, LogLevel.Info);
+			Write(message, TraceLevel.Info);
 		}
 
 		/// <summary>
@@ -172,16 +169,16 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void ConsoleInfo(string format, params object[] args)
 		{
-			ConsoleInfo(String.Format(format, args));
+			ConsoleInfo(string.Format(format, args));
 		}
 
 		/// <summary>
 		/// Writes a debug string to the log file.
 		/// </summary>
 		/// <param name="message">The message to be written.</param>
-		public void Debug(String message)
+		public void Debug(string message)
 		{
-			Write(message, LogLevel.Debug);
+			Write(message, TraceLevel.Verbose);
 		}
 
 		/// <summary>
@@ -191,7 +188,7 @@ namespace TShockAPI
 		/// <param name="args">The format arguments.</param>
 		public void Debug(string format, params object[] args)
 		{
-			Debug(String.Format(format, args));
+			Debug(string.Format(format, args));
 		}
 
 		/// <summary>
@@ -199,7 +196,7 @@ namespace TShockAPI
 		/// </summary>
 		/// <param name="message"></param>
 		/// <param name="level"></param>
-		public void Write(string message, LogLevel level)
+		public void Write(string message, TraceLevel level)
 		{
 			if (!MayWriteType(level))
 				return;
@@ -214,7 +211,7 @@ namespace TShockAPI
 					caller = meth.DeclaringType.Name;
 			}
 
-			var logEntry = String.Format("{0} - {1}: {2}: {3}",
+			var logEntry = string.Format("{0} - {1}: {2}: {3}",
 					DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
 					caller, level.ToString().ToUpper(), message);
 			try

--- a/TShockAPI/TextLog.cs
+++ b/TShockAPI/TextLog.cs
@@ -33,22 +33,9 @@ namespace TShockAPI
 		private readonly LogLevel _logLevel;
 
 		/// <summary>
-		/// Log file name
+		/// File name of the Text log
 		/// </summary>
-		public static string fileName { get; private set; }
-
-		/// <summary>
-		/// Name of the TextLog
-		/// </summary>
-		public string Name
-		{
-			get { return "Text Log Writer"; }
-		}
-
-		public bool Sql
-		{
-			get { return false; }
-		}
+		public string FileName { get; set; }
 
 		/// <summary>
 		/// Creates the log file stream and sets the initial log level.
@@ -58,7 +45,7 @@ namespace TShockAPI
 		/// <param name="clear">Whether or not to clear the log file on initialization.</param>
 		public TextLog(string filename, LogLevel logLevel, bool clear)
 		{
-			fileName = filename;
+			FileName = filename;
 			_logLevel = logLevel;
 			_logWriter = new StreamWriter(filename, !clear);
 		}


### PR DESCRIPTION
I changed 'String' to 'string' as both were being used.