### PR TITLE
Add opt-in config to enable sending stats to stats.tshock.co

### DIFF
--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -433,6 +433,9 @@ namespace TShockAPI
 		[Description("The minimum password length for new user accounts. Minimum value is 4.")]
 		public int MinimumPasswordLength = 4;
 
+		[Description("Enable to send stats to stats.tshock.co")]
+		public bool EnableSendStatsToTShockToHelpTheProject = false;
+
 		/// <summary>
 		/// Reads a configuration file from a given path
 		/// </summary>

--- a/TShockAPI/StatTracker.cs
+++ b/TShockAPI/StatTracker.cs
@@ -21,11 +21,12 @@ namespace TShockAPI
 
 		public void Initialize()
 		{
-			if (!initialized)
+			if (!initialized && TShock.Config.EnableSendStatsToTShockToHelpTheProject)
 			{
-				initialized = true;
+				
 				ThreadPool.QueueUserWorkItem(SendUpdate);
 			}
+			initialized = true;
 		}
 
 		private void SendUpdate(object info)


### PR DESCRIPTION
"phone home" functionality should be in my opinion be disabled pr default. The property name is trying to encourage the admins to enable this. EnableSendStatsToTShockToHelpTheProject