### PR TITLE
Serverpassword syntax error gave wrong command

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -3600,7 +3600,7 @@ namespace TShockAPI
 		{
 			if (args.Parameters.Count != 1)
 			{
-                args.Player.SendErrorMessage("Invalid syntax! Proper syntax: {0}serverpassword \"<new password>\"", Specifier);
+				args.Player.SendErrorMessage("Invalid syntax! Proper syntax: {0}serverpassword \"<new password>\"", Specifier);
 				return;
 			}
 			string passwd = args.Parameters[0];

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -3600,7 +3600,7 @@ namespace TShockAPI
 		{
 			if (args.Parameters.Count != 1)
 			{
-				args.Player.SendErrorMessage("Invalid syntax! Proper syntax: {0}password \"<new password>\"", Specifier);
+                args.Player.SendErrorMessage("Invalid syntax! Proper syntax: {0}serverpassword \"<new password>\"", Specifier);
 				return;
 			}
 			string passwd = args.Parameters[0];


### PR DESCRIPTION
The syntax error message for serverpassword said the command was "/password <new password>" but it should be "/serverpassword ..."
