### PR TITLE
SSC Saving over playes with Ignore SSC perms in group or temp group

### DIFF
--- a/TShockAPI/DB/CharacterManager.cs
+++ b/TShockAPI/DB/CharacterManager.cs
@@ -159,6 +159,11 @@ namespace TShockAPI.DB
 			if (!player.IsLoggedIn)
 				return false;
 			
+		        if ((player.tempGroup != null && player.tempGroup.HasPermission(Permissions.bypassssc)) || player.Group.HasPermission(Permissions.bypassssc))
+	        	{
+	        		TShock.Log.ConsoleInfo("Skipping SSC Backup for " + player.User.Name);
+	                	return true;
+	            	}
 			
 			if (!GetPlayerData(player, player.User.ID).exists)
 			{

--- a/TShockAPI/DB/CharacterManager.cs
+++ b/TShockAPI/DB/CharacterManager.cs
@@ -161,7 +161,7 @@ namespace TShockAPI.DB
 			
 		        if ((player.tempGroup != null && player.tempGroup.HasPermission(Permissions.bypassssc)) || player.Group.HasPermission(Permissions.bypassssc))
 	        	{
-	        		TShock.Log.ConsoleInfo("Skipping SSC Backup for " + player.User.Name);
+	        		TShock.Log.ConsoleInfo("Skipping SSC Backup for " + player.User.Name); // Debug code
 	                	return true;
 	            	}
 			

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -430,6 +430,11 @@ namespace TShockAPI
 			}
 			try
 			{
+		                if ((tempGroup != null && tempGroup.HasPermission(Permissions.bypassssc)) || Group.HasPermission(Permissions.bypassssc))
+                		{
+                    		TShock.Log.ConsoleInfo("Skipping SSC Backup for " + User.Name); // Debug Code
+            			return true;
+        			}
 				PlayerData.CopyCharacter(this);
 				TShock.CharacterDB.InsertPlayerData(this);
 				return true;


### PR DESCRIPTION
I've added these 2 changes to my server to avoid users who are in temp groups or been given the ignore ssc perms AFTER login from having their SSC inventory saved over.

Related issue:
https://github.com/NyxStudios/TShock/issues/1112