### PR TITLE
Replace interpolated strings

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -972,8 +972,8 @@ namespace TShockAPI
 						}
 						else if (Itembans.ItemIsBanned(player.TPlayer.inventory[player.TPlayer.selectedItem].name, player))
 						{
-							player.Disable($"holding banned item: {player.TPlayer.inventory[player.TPlayer.selectedItem].name}", flags);
-							player.SendErrorMessage($"You are holding a banned item: {player.TPlayer.inventory[player.TPlayer.selectedItem].name}");
+							player.Disable(String.Format("holding banned item: {0}", player.TPlayer.inventory[player.TPlayer.selectedItem].name), flags);
+							player.SendErrorMessage(String.Format("You are holding a banned item: {0}", player.TPlayer.inventory[player.TPlayer.selectedItem].name));
 						}
 					}
 					else if (!Main.ServerSideCharacter || (Main.ServerSideCharacter && player.IsLoggedIn))
@@ -1052,8 +1052,8 @@ namespace TShockAPI
 						}
 						else if (Itembans.ItemIsBanned(player.TPlayer.inventory[player.TPlayer.selectedItem].name, player))
 						{
-							player.Disable($"holding banned item: {player.TPlayer.inventory[player.TPlayer.selectedItem].name}", flags);
-							player.SendErrorMessage($"You are holding a banned item: {player.TPlayer.inventory[player.TPlayer.selectedItem].name}");
+							player.Disable(String.Format("holding banned item: {0}", player.TPlayer.inventory[player.TPlayer.selectedItem].name), flags);
+							player.SendErrorMessage(String.Format("You are holding a banned item: {0}", player.TPlayer.inventory[player.TPlayer.selectedItem].name));
 						}
 					}
 
@@ -1093,7 +1093,7 @@ namespace TShockAPI
 		{
 			if (args.Handled)
 				return;
-			
+
 			if (!Config.AllowCrimsonCreep && (args.Type == TileID.Dirt || args.Type == TileID.FleshWeeds
 				|| TileID.Sets.Crimson[args.Type]))
 			{


### PR DESCRIPTION
String interpolation added in 049abd91460e7921da588f44a1a247764675746c requires C# 6.0 or Mono >= 4.0 which is not available in Debian, Gentoo, openSUSE, and Ubuntu stable repositories. Requiring  experimental/unstable packages while breaking backwards compatibility is not a good trade-off.

Signed-off-by: Beau Hastings <beausy@gmail.com>