### PR TITLE
Concurrent Dictionary Access Fix

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2137,8 +2137,9 @@ namespace TShockAPI
 				{
 					args.Player.TilePlaceThreshold++;
 					var coords = new Vector2(tileX, tileY);
-					if (!args.Player.TilesCreated.ContainsKey(coords))
-						args.Player.TilesCreated.Add(coords, Main.tile[tileX, tileY]);
+					lock (args.Player.TilesCreated)
+						if (!args.Player.TilesCreated.ContainsKey(coords))
+							args.Player.TilesCreated.Add(coords, Main.tile[tileX, tileY]);
 				}
 
 				if ((action == EditAction.KillTile || action == EditAction.KillTileNoItem || action == EditAction.KillWall) && Main.tileSolid[Main.tile[tileX, tileY].type] &&
@@ -2146,8 +2147,9 @@ namespace TShockAPI
 				{
 					args.Player.TileKillThreshold++;
 					var coords = new Vector2(tileX, tileY);
-					if (!args.Player.TilesDestroyed.ContainsKey(coords))
-						args.Player.TilesDestroyed.Add(coords, Main.tile[tileX, tileY]);
+					lock (args.Player.TilesDestroyed)
+						if (!args.Player.TilesDestroyed.ContainsKey(coords))
+							args.Player.TilesDestroyed.Add(coords, Main.tile[tileX, tileY]);
 				}
 				return false;
 			}
@@ -2239,8 +2241,9 @@ namespace TShockAPI
 			{
 				args.Player.TilePlaceThreshold++;
 				var coords = new Vector2(x, y);
-				if (!args.Player.TilesCreated.ContainsKey(coords))
-					args.Player.TilesCreated.Add(coords, Main.tile[x, y]);
+				lock (args.Player.TilesCreated)
+					if (!args.Player.TilesCreated.ContainsKey(coords))
+						args.Player.TilesCreated.Add(coords, Main.tile[x, y]);
 			}
 
 			return false;

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -894,7 +894,8 @@ namespace TShockAPI
 					{
 						player.TileKillThreshold = 0;
 						//We don't want to revert the entire map in case of a disable.
-						player.TilesDestroyed.Clear();
+						lock (player.TilesDestroyed)
+							player.TilesDestroyed.Clear();
 					}
 
 					if (player.TilesCreated != null)
@@ -902,8 +903,10 @@ namespace TShockAPI
 						if (player.TilePlaceThreshold >= Config.TilePlaceThreshold)
 						{
 							player.Disable("Reached TilePlace threshold", flags);
-							TSPlayer.Server.RevertTiles(player.TilesCreated);
-							player.TilesCreated.Clear();
+							lock (player.TilesCreated) {
+								TSPlayer.Server.RevertTiles(player.TilesCreated);
+								player.TilesCreated.Clear();
+							}
 						}
 					}
 					if (player.TilePlaceThreshold > 0)


### PR DESCRIPTION
A server has been suffering from several performance issues and I tracked the problem down to threads getting stuck in 

> System.Collections.Generic.Dictionary`2[[...]].FindEntry()

After I synchronized the two dictionaries of TSPlayer with this code, the issues were resolved.

There's also [this arcticle](https://blogs.msdn.microsoft.com/tess/2009/12/21/high-cpu-in-net-app-using-a-static-generic-dictionary/) which explains this problem of unsynchronized dictionaries in a bit more detail.
