### PR TITLE
Show proper error message at db connect fail

### DIFF
--- a/TShockAPI/Extensions/DbExt.cs
+++ b/TShockAPI/Extensions/DbExt.cs
@@ -60,14 +60,21 @@ namespace TShockAPI.DB
 		public static QueryResult QueryReader(this IDbConnection olddb, string query, params object[] args)
 		{
 			var db = olddb.CloneEx();
-			db.Open();
-			using (var com = db.CreateCommand())
+			try
 			{
-				com.CommandText = query;
-				for (int i = 0; i < args.Length; i++)
-					com.AddParameter("@" + i, args[i]);
+				db.Open();
+				using (var com = db.CreateCommand())
+				{
+					com.CommandText = query;
+					for (int i = 0; i < args.Length; i++)
+						com.AddParameter("@" + i, args[i]);
 
-				return new QueryResult(db, com.ExecuteReader());
+					return new QueryResult(db, com.ExecuteReader());
+				}
+			}
+			catch (Exception ex)
+			{
+				throw new Exception("Fatal TShock initialization exception: failed to connect to MySQL database. See inner exception for details.", ex);
 			}
 		}
 


### PR DESCRIPTION
If server cannot connect to the database (only experienced it at MySQL) the console will simply close without any error message or log, leaving the user confused. 