### PR TITLE
Added the SetDungeon command.

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -512,7 +512,12 @@ namespace TShockAPI
 				AllowServer = false,
 				HelpText = "Sets the world's spawn point to your location."
 			});
-			add(new Command(Permissions.worldsettle, Settle, "settle")
+            add(new Command(Permissions.worldspawn, SetDungeon, "setdungeon")
+            {
+                AllowServer = false,
+                HelpText = "Sets the dungeon's position to your location."
+            });
+            add(new Command(Permissions.worldsettle, Settle, "settle")
 			{
 				HelpText = "Forces all liquids to update immediately."
 			});
@@ -3612,7 +3617,15 @@ namespace TShockAPI
 			args.Player.SendSuccessMessage("Spawn has now been set at your location.");
 		}
 
-		private static void Reload(CommandArgs args)
+        private static void SetDungeon(CommandArgs args)
+        {
+            Main.dungeonX = args.Player.TileX + 1;
+            Main.dungeonY = args.Player.TileY + 3;
+            SaveManager.Instance.SaveWorld(false);
+            args.Player.SendSuccessMessage("The dungeon's position has now been set at your location.");
+        }
+
+        private static void Reload(CommandArgs args)
 		{
 			TShock.Utils.Reload(args.Player);
 

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -305,6 +305,9 @@ namespace TShockAPI
 		[Description("User can set the world spawn.")]
 		public static readonly string worldspawn = "tshock.world.setspawn";
 
+	    [Description( "User can set the dungeon's location." )]
+        public static readonly string dungeonposition = "tshock.world.setdungeon";
+
 		[Description("User can drop a meteor.")]
 		public static readonly string dropmeteor = "tshock.world.time.dropmeteor";
 


### PR DESCRIPTION
Added feature requested in #1140.
The dungeon still has to be physically moved but this can be accomplished using WorldEdit, allowing for live "dungeon moving". You also need to kill the already existant Cultists or reload the map.

![capture 2016-07-01 18_29_12](https://cloud.githubusercontent.com/assets/836345/16535982/4e532746-3fba-11e6-95ef-51317537e9bf.png)
![capture 2016-07-01 18_27_40](https://cloud.githubusercontent.com/assets/836345/16535985/5084a3e6-3fba-11e6-80bc-3714bde6b3a4.png)

For some reason, github shows my code as being wrongly indented when its not the case.

