### PR TITLE
Fix bug: players cannot place sensors

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1743,6 +1743,15 @@ namespace TShockAPI
 							Main.tile[realx, realy].active(false);
 							changed = true;
 						}
+						// Sensors
+						if(newtile.Type == TileID.LogicSensor && !Main.tile[realx, realy].active())
+						{
+							Main.tile[realx, realy].type = newtile.Type;
+							Main.tile[realx, realy].frameX = newtile.FrameX;
+							Main.tile[realx, realy].frameY = newtile.FrameY;
+							Main.tile[realx, realy].active(true);
+							changed = true;
+						}
 
 						if (tile.active() && newtile.Active)
 						{


### PR DESCRIPTION
Players without permission `Permissions.allowclientsideworldedit` can't place sensors.
When one places a sensor the first time, the sensor will disappear, but it will appear as the player try again.