### PR TITLE
Fixes #1252 and #1160

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -30,6 +30,8 @@ using TShockAPI.DB;
 using TShockAPI.Net;
 using Terraria;
 using Terraria.ObjectData;
+using Terraria.DataStructures;
+using Terraria.GameContent.Tile_Entities;
 
 namespace TShockAPI
 {
@@ -1255,6 +1257,7 @@ namespace TShockAPI
 					{ PacketTypes.CatchNPC, HandleCatchNpc },
 					{ PacketTypes.KillPortal, HandleKillPortal },
 					{ PacketTypes.PlaceTileEntity, HandlePlaceTileEntity },
+					{ PacketTypes.PlaceItemFrame, HandlePlaceItemFrame },
 					{ PacketTypes.ToggleParty, HandleToggleParty }
 				};
 		}
@@ -4134,6 +4137,42 @@ namespace TShockAPI
 
 			if (TShock.CheckRangePermission(args.Player, x, y))
 			{
+				return true;
+			}
+
+			return false;
+		}
+
+		private static bool HandlePlaceItemFrame(GetDataHandlerArgs args)
+		{
+			var x = args.Data.ReadInt16();
+			var y = args.Data.ReadInt16();
+			var itemID = args.Data.ReadInt16();
+			var prefix = args.Data.ReadInt8();
+			var stack = args.Data.ReadInt16();
+			var itemFrame = (TEItemFrame)TileEntity.ByID[TEItemFrame.Find(x, y)];
+
+			if (TShock.CheckIgnores(args.Player))
+			{
+				NetMessage.SendData(86, -1, -1, "", itemFrame.ID, 0, 1);
+				return true;
+			}
+
+			if (TShock.CheckTilePermission(args.Player, x, y))
+			{
+				NetMessage.SendData(86, -1, -1, "", itemFrame.ID, 0, 1);
+				return true;
+			}
+
+			if (TShock.CheckRangePermission(args.Player, x, y))
+			{
+				NetMessage.SendData(86, -1, -1, "", itemFrame.ID, 0, 1);
+				return true;
+			}
+
+			if (itemFrame.item?.netID == args.TPlayer.inventory[args.TPlayer.selectedItem]?.netID)
+			{
+				NetMessage.SendData(86, -1, -1, "", itemFrame.ID, 0, 1);
 				return true;
 			}
 

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -974,8 +974,7 @@ namespace TShockAPI
 		/// <param name="red">The amount of red color to factor in. Max: 255.</param>
 		/// <param name="green">The amount of green color to factor in. Max: 255</param>
 		/// <param name="blue">The amount of blue color to factor in. Max: 255</param>
-		/// <param name="messageLength">The number of pixels before the message splits lines. Defaults to -1, which is the client's screen width.</param>
-		public virtual void SendMessage(string msg, byte red, byte green, byte blue, int messageLength = -1)
+		public virtual void SendMessage(string msg, byte red, byte green, byte blue)
 		{
 			if (msg.Contains("\n"))
 			{
@@ -986,7 +985,7 @@ namespace TShockAPI
 				}
 				return;
 			}
-			SendData(PacketTypes.SmartTextMessage, msg, 255, red, green, blue, messageLength);
+			SendData(PacketTypes.SmartTextMessage, msg, 255, red, green, blue, -1);
 		}
 
 		/// <summary>
@@ -997,8 +996,7 @@ namespace TShockAPI
 		/// <param name="green">The amount of green color to factor in. Max: 255.</param>
 		/// <param name="blue">The amount of blue color to factor in. Max: 255.</param>
 		/// <param name="ply">The player who receives the message.</param>
-		/// <param name="messageLength">The number of pixels before the message splits lines. Defaults to -1, which is the client's screen width.</param>
-		public virtual void SendMessageFromPlayer(string msg, byte red, byte green, byte blue, int ply, int messageLength = -1)
+		public virtual void SendMessageFromPlayer(string msg, byte red, byte green, byte blue, int ply)
 		{
 			if (msg.Contains("\n"))
 			{
@@ -1009,7 +1007,7 @@ namespace TShockAPI
 				}
 				return;
 			}
-			SendDataFromPlayer(PacketTypes.SmartTextMessage, ply, msg, red, green, blue, messageLength);
+			SendDataFromPlayer(PacketTypes.SmartTextMessage, ply, msg, red, green, blue, -1);
 		}
 
 		/// <summary>
@@ -1246,7 +1244,7 @@ namespace TShockAPI
 			SendMessage(msg, color.R, color.G, color.B);
 		}
 
-		public override void SendMessage(string msg, byte red, byte green, byte blue, int messageLength = -1)
+		public override void SendMessage(string msg, byte red, byte green, byte blue)
 		{
 			this.CommandOutput.Add(msg);
 		}

--- a/TShockAPI/TSServerPlayer.cs
+++ b/TShockAPI/TSServerPlayer.cs
@@ -50,7 +50,7 @@ namespace TShockAPI
 			SendMessage(msg, color.R, color.G, color.B);
 		}
 
-		public override void SendMessage(string msg, byte red, byte green, byte blue, int messageLength = -1)
+		public override void SendMessage(string msg, byte red, byte green, byte blue)
 		{
 			Console.WriteLine(msg);
 		}


### PR DESCRIPTION
**Changes:**

- The  `messageLength` parameter was removed from TSPlayer.SendMessage because it has no use (see Slack for further details).

- Players can no longer modify protected Item Frames.

- Players can no longer duplicate items using Item Frames.