### PR TITLE
Fixed item duplication issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Players can no longer quick stack items into region protected chests (@ProfessorXZ)
 * Rope placement is no longer blocked by range checks (@ProfessorXZ)
 * The Drill Containment Unit breaks blocks properly now (@ProfessorXZ)
+* Fixed item duplications caused by range checks and invalid netIDs (@ProfessorXZ)
 * Fixed Expert mode coin duplication (@ProfessorXZ)
 * Players are no longer able to place liquids using LoadNetModule packet (@ProfessorXZ)
 * Explosives are no longer blocked by range checks (@ProfessorXZ)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1907,6 +1907,12 @@ namespace TShockAPI
 
 				var style = args.Data.ReadInt8();
 
+				if (editData < 0)
+				{
+					args.Player.SendTileSquare(tileX, tileY, 4);
+					return true;
+				}
+
 				if (OnTileEdit(args.Player, tileX, tileY, action, type, editData, style))
 					return true;
 				if (!TShock.Utils.TilePlacementValid(tileX, tileY))

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3322,7 +3322,8 @@ namespace TShockAPI
 			// player is attempting to crash clients
 			if (type < -48 || type >= Main.maxItemTypes)
 			{
-				args.Player.SendData(PacketTypes.ItemDrop, "", id);
+				// Causes item duplications. Will be re added later if necessary
+				//args.Player.SendData(PacketTypes.ItemDrop, "", id);
 				return true;
 			}
 
@@ -3336,7 +3337,8 @@ namespace TShockAPI
 			{
 				if (TShock.CheckRangePermission(args.Player, (int)(Main.item[id].position.X / 16f), (int)(Main.item[id].position.Y / 16f)))
 				{
-					args.Player.SendData(PacketTypes.ItemDrop, "", id);
+					// Causes item duplications. Will be re added if necessary
+					//args.Player.SendData(PacketTypes.ItemDrop, "", id);
 					return true;
 				}
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1233,7 +1233,7 @@ namespace TShockAPI
 					{ PacketTypes.UpdateNPCHome, UpdateNPCHome },
 					{ PacketTypes.PlayerAddBuff, HandlePlayerAddBuff },
 					{ PacketTypes.ItemDrop, HandleItemDrop },
-					{ PacketTypes.UpdateItemDrop, HandleUpdateItemDrop },
+					{ PacketTypes.UpdateItemDrop, HandleItemDrop },
 					{ PacketTypes.ItemOwner, HandleItemOwner },
 					{ PacketTypes.PlayerHp, HandlePlayerHp },
 					{ PacketTypes.PlayerMana, HandlePlayerMana },
@@ -3375,79 +3375,6 @@ namespace TShockAPI
 			if (TShock.CheckIgnores(args.Player))
 			{
 				args.Player.SendData(PacketTypes.ItemDrop, "", id);
-				return true;
-			}
-
-			return false;
-		}
-
-		private static bool HandleUpdateItemDrop(GetDataHandlerArgs args)
-		{
-			var itemID = args.Data.ReadInt16();
-			var position = new Vector2(args.Data.ReadSingle(), args.Data.ReadSingle());
-			var velocity = new Vector2(args.Data.ReadSingle(), args.Data.ReadSingle());
-			var stacks = args.Data.ReadInt16();
-			var prefix = args.Data.ReadInt8();
-			var noDelay = args.Data.ReadInt8() == 1;
-			var itemNetID = args.Data.ReadInt16();
-
-			if (OnItemDrop(itemID, position, velocity, stacks, prefix, noDelay, itemNetID))
-				return true;
-
-			// Invalid Net IDs can cause client crashes
-			if (itemNetID < -48 || itemNetID >= Main.maxItemTypes)
-			{
-				args.Player.SendData(PacketTypes.ItemDrop, "", itemID);
-				return true;
-			}
-
-			if (prefix > Item.maxPrefixes) // Make sure the prefix is a legit value
-			{
-				args.Player.SendData(PacketTypes.ItemDrop, "", itemID);
-				return true;
-			}
-
-			if (itemNetID == 0) //Item removed, let client do this to prevent item duplication client side (but only if it passed the range check)
-			{
-				if (TShock.CheckRangePermission(args.Player, (int)(Main.item[itemID].position.X / 16f), (int)(Main.item[itemID].position.Y / 16f)))
-				{
-					args.Player.SendData(PacketTypes.ItemDrop, "", itemID);
-					return true;
-				}
-
-				return false;
-			}
-
-			if (TShock.CheckRangePermission(args.Player, (int)(position.X / 16f), (int)(position.Y / 16f)))
-			{
-				args.Player.SendData(PacketTypes.ItemDrop, "", itemID);
-				return true;
-			}
-
-			if (Main.item[itemID].active && Main.item[itemID].netID != itemNetID) //stop the client from changing the item type of a drop but only if the client isn't picking up the item
-			{
-				args.Player.SendData(PacketTypes.ItemDrop, "", itemID);
-				return true;
-			}
-
-			Item item = new Item();
-			item.netDefaults(itemNetID);
-			if ((stacks > item.maxStack || stacks <= 0) || (TShock.Itembans.ItemIsBanned(item.name, args.Player) && !args.Player.HasPermission(Permissions.allowdroppingbanneditems)))
-			{
-				args.Player.SendData(PacketTypes.ItemDrop, "", itemID);
-				return true;
-			}
-			if ((Main.ServerSideCharacter) && (DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond - args.Player.LoginMS < TShock.ServerSideCharacterConfig.LogonDiscardThreshold))
-			{
-				//Player is probably trying to sneak items onto the server in their hands!!!
-				TShock.Log.ConsoleInfo("Player {0} tried to sneak {1} onto the server!", args.Player.Name, item.name);
-				args.Player.SendData(PacketTypes.ItemDrop, "", itemID);
-				return true;
-
-			}
-			if (TShock.CheckIgnores(args.Player))
-			{
-				args.Player.SendData(PacketTypes.ItemDrop, "", itemID);
 				return true;
 			}
 


### PR DESCRIPTION
**Changes:**

- Fixed item duplication caused by range checks and invalid netIDs

- Fixed an issue where clients could send corrupt packets by sending invalid tile IDs in packet 17