### PR TITLE
Fix Junction Box permission issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * The Drill Containment Unit breaks blocks properly now (@ProfessorXZ)
 * Fixed Expert mode coin duplication (@ProfessorXZ)
 * Players are no longer able to place liquids using LoadNetModule packet (@ProfessorXZ)
+* Fixed a bug where players couldn't hammer a Junction Box without "allowclientsideworldedit" permission (@Patrikkk)
 
 ## TShock 4.3.17
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1741,6 +1741,10 @@ namespace TShockAPI
 							continue;
 						}
 
+						// Junction Box
+						if (tile.type == TileID.WirePipe)
+							return false;
+
 						// Orientable tiles
 						if (tile.type == newtile.Type && orientableTiles.Contains(tile.type))
 						{


### PR DESCRIPTION
Users without `allowclientsideworldedit` permission couldn't hammer and
change direction of Junction Box.
Code tested and functional.
(idk if I did it right tho lol)