### PR TITLE
Fix #1287 | Quickstack to nearby chests issue

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -503,7 +503,7 @@ namespace TShockAPI
 					return;
 				}
 
-				if (CheckRangePermission(tsplr, (int)args.Position.X, (int)args.Position.Y))
+				if (CheckRangePermission(tsplr, args.Chest.x, args.Chest.y))
 				{
 					args.Handled = true;
 					return;


### PR DESCRIPTION
CheckRangePermission accepts coordinate which is divided by 16.
The Position vector which is passed in ForceItemIntoChestEventArgs is
multiplied by 16.
(To be more exact. `new Vector2((float)(Main.chest[i].x * 16 + 16),
(float)(Main.chest[i].y * 16 + 16))`)
The + 16 is there to get the middle of the player so it can make an
accurate check when checking distance between chest and player.
So I'm not really sure if the Position arg should be even passed in the
eventarg.

Anyway, CheckRangePermission always returned true because of the above,
and handled the event, so players could never quickstack into nearby,
unless they had RangeChecks off.
"True if the player should not be able to place the tile." (In our case,
stack items into chest)

Why doesn't CheckRangePermission contain a check on an actual range
permission of the player's group? So groups with the permission could
bypass the check.
Just wondering if there is any legit reason for that.