### PR TITLE
Auth rewrite. Closes #1064.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This is the rolling changelog for TShock for Terraria. Use past tense when adding new entries; sign your name off when you add or change something. This should primarily be things like user changes, not necessarily codebase changes unless it's really relevant or large.
 
 ## Upcoming Changes
+* Security improvement: The auth system is now automatically disabled if a superadmin exists in the database (@Enerdy)
+* Removed the `auth-verify` command since `auth` now serves its purpose when necessary (@Enerdy)
 
 ## TShock 4.3.19
 * Compatibility with Terraria 1.3.3.3 (@Simon311)

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -4618,10 +4618,15 @@ namespace TShockAPI
 		{
 			if (TShock.AuthToken == 0)
 			{
-				args.Player.SendWarningMessage("Auth is disabled. This incident has been logged.");
-				TShock.Utils.ForceKick(args.Player, "Auth system is disabled.", true, true);
-				TShock.Log.Warn("{0} attempted to use {1}auth even though it's disabled.", args.Player.IP, Specifier);
-				return;
+				if (args.Player.Group.Name == new SuperAdminGroup().Name)
+					args.Player.SendInfoMessage("The auth system is already disabled.");
+				else
+				{
+					args.Player.SendWarningMessage("The auth system is disabled. This incident has been logged.");
+					TShock.Utils.ForceKick(args.Player, "Auth system is disabled.", true, true);
+					TShock.Log.Warn("{0} attempted to use {1}auth even though it's disabled.", args.Player.IP, Specifier);
+					return;
+				}
 			}
 
 			// If the user account is already a superadmin (permanent), disable the system

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -208,7 +208,7 @@ namespace TShockAPI
 				ChatCommands.Add(cmd);
 			};
 
-			add(new Command(AuthToken, "auth", "auth-verify")
+			add(new Command(AuthToken, "auth")
 			{
 				AllowServer = false,
 				HelpText = "Used to authenticate as superadmin when first setting up TShock."

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -29,16 +29,16 @@ namespace TShockAPI
 	{
 		// tshock.account nodes
 
-		[Description("User can register account in game")]
+		[Description("User can register account in game.")]
 		public static readonly string canregister = "tshock.account.register";
 
-		[Description("User can login in game")]
+		[Description("User can login in game.")]
 		public static readonly string canlogin = "tshock.account.login";
 
-		[Description("User can logout in game")]
+		[Description("User can logout in game.")]
 		public static readonly string canlogout = "tshock.account.logout";
 
-		[Description("User can change password in game")]
+		[Description("User can change password in game.")]
 		public static readonly string canchangepassword = "tshock.account.changepassword";
 
 		// tshock.admin nodes
@@ -79,10 +79,10 @@ namespace TShockAPI
 		[Description("User can manage regions.")]
 		public static readonly string manageregion = "tshock.admin.region";
 
-		[Description("User can mute and unmute users")]
+		[Description("User can mute and unmute users.")]
 		public static readonly string mute = "tshock.admin.mute";
 
-		[Description("User can see the id of players with /who")]
+		[Description("User can see the id of players with /who.")]
 		public static readonly string seeids = "tshock.admin.seeplayerids";
 
 		[Description("User can save all the players SSI state.")]
@@ -148,7 +148,7 @@ namespace TShockAPI
 		[Description("Prevents your actions from being ignored if damage is too high.")]
 		public static readonly string ignoredamagecap = "tshock.ignore.damage";
 
-		[Description("Bypass server side character checks")]
+		[Description("Bypass server side character checks.")]
 		public static readonly string bypassssc = "tshock.ignore.ssc";
 
 		[Description("Allow unrestricted SendTileSquare usage, for client side world editing.")]
@@ -200,10 +200,10 @@ namespace TShockAPI
 		[Description("User can kill all enemy npcs.")]
 		public static readonly string butcher = "tshock.npc.butcher";
 
-		[Description("User can summon bosses using items")]
+		[Description("User can summon bosses using items.")]
 		public static readonly string summonboss = "tshock.npc.summonboss";
 
-		[Description("User can start invasions (Goblin/Snow Legion) using items")]
+		[Description("User can start invasions (Goblin/Snow Legion) using items.")]
 		public static readonly string startinvasion = "tshock.npc.startinvasion";
 
 		[Description("User can clear the list of users who have completed an angler quest that day.")]
@@ -211,7 +211,8 @@ namespace TShockAPI
 
 		// tshock.superadmin nodes
 
-		[Description("Meant for super admins only.")]
+		[Description("This permission is no longer used.")]
+		[Obsolete("No longer used.")]
 		public static readonly string authverify = "tshock.superadmin.authverify";
 
 		[Description("Meant for super admins only.")]
@@ -252,7 +253,7 @@ namespace TShockAPI
 		[Description("User can use /spawn.")]
 		public static readonly string spawn = "tshock.tp.spawn";
 
-		[Description("User can use the Rod of Discor.")] 
+		[Description("User can use the Rod of Discord.")]
 		public static readonly string rod = "tshock.tp.rod";
 
 		[Description("User can use wormhole potions.")]
@@ -287,7 +288,7 @@ namespace TShockAPI
 		[Description("User can change the homes of NPCs.")]
 		public static readonly string movenpc = "tshock.world.movenpc";
 
-		[Description("User can convert hallow into corruption and vice-versa")]
+		[Description("User can convert hallow into corruption and vice-versa.")]
 		public static readonly string converthardmode = "tshock.world.converthardmode";
 
 		[Description("User can force the server to Halloween mode.")]
@@ -322,7 +323,7 @@ namespace TShockAPI
 
 		[Description("User can modify the world.")]
 		public static readonly string canbuild = "tshock.world.modify";
-		
+
 		[Description("User can paint tiles.")]
 		public static readonly string canpaint = "tshock.world.paint";
 
@@ -345,7 +346,7 @@ namespace TShockAPI
 
 		[Description("User can kill others.")]
 		public static readonly string kill = "tshock.kill";
-		
+
 		[Description("Allows you to bypass the max slots for up to 5 slots above your max.")]
 		public static readonly string reservedslot = "tshock.reservedslot";
 
@@ -364,10 +365,10 @@ namespace TShockAPI
 		[Description("User can heal players.")]
 		public static readonly string heal = "tshock.heal";
 
-		[Description("User can use party chat in game")]
+		[Description("User can use party chat in game.")]
 		public static readonly string canpartychat = "tshock.partychat";
 
-		[Description("User can talk in third person")]
+		[Description("User can talk in third person.")]
 		public static readonly string cantalkinthird = "tshock.thirdperson";
 
 		[Description("User can get the server info.")]
@@ -376,10 +377,10 @@ namespace TShockAPI
 		[Description("Player recovers health as damage is taken.  Can be one shotted.")]
 		public static readonly string godmode = "tshock.godmode";
 
-		[Description("User can godmode other players")]
+		[Description("User can godmode other players.")]
 		public static readonly string godmodeother = "tshock.godmode.other";
 
-		[Description("Player can chat")] 
+		[Description("Player can chat.")]
 		public static readonly string canchat = "tshock.canchat";
 
 		[Description("Player can use banned projectiles.")]

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -814,7 +814,7 @@ namespace TShockAPI
 				AuthToken = r.Next(100000, 10000000);
 				Console.ForegroundColor = ConsoleColor.Yellow;
 				Console.WriteLine("TShock Notice: To become SuperAdmin, join the game and type {0}auth {1}", Commands.Specifier, AuthToken);
-				Console.WriteLine("This token will display until disabled by verification. ({0}auth-verify)", Commands.Specifier);
+				Console.WriteLine("This token will display until disabled by verification. ({0}auth)", Commands.Specifier);
 				Console.ResetColor();
 				File.WriteAllText(Path.Combine(SavePath, "authcode.txt"), AuthToken.ToString());
 			}


### PR DESCRIPTION
A possible solution to the problem. Here are the changes included:
* The auth system will now be disabled on start-up if a superadmin user exists. An `auth.lck` file is still created to avoid having to fetch all users in the future, which in big, old servers could potentially slow down the start-up by a lot.
* The `auth-verify` command has been removed. `auth` now checks if the player is a **permanent** superadmin on use and disables the system if so.
* The `auth` command is now more informative in its error messages, and should not fail due to thrown exceptions anymore.
This closes #1064.