### PR TITLE
Add /accountinfo, fix offline bans exploit, fix #1309 more

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -244,6 +244,10 @@ namespace TShockAPI
 				DoLog = false,
 				HelpText = "Registers you an account."
 			});
+			add(new Command(Permissions.checkaccountinfo, ViewAccountInfo, "accountinfo", "ai")
+			{
+				HelpText = "Shows information about a user."
+			});
 			#endregion
 			#region Admin Commands
 			add(new Command(Permissions.ban, Ban, "ban")
@@ -300,7 +304,7 @@ namespace TShockAPI
 			});
 			add(new Command(Permissions.userinfo, GrabUserUserInfo, "userinfo", "ui")
 			{
-				HelpText = "Shows information about a user."
+				HelpText = "Shows information about a player."
 			});
 			#endregion
 			#region Annoy Commands
@@ -1203,6 +1207,43 @@ namespace TShockAPI
 					message.Append(" | Logged in as: ").Append(players[0].User.Name).Append(" | Group: ").Append(players[0].Group.Name);
 				args.Player.SendSuccessMessage(message.ToString());
 			}
+		}
+
+		private static void ViewAccountInfo(CommandArgs args)
+		{
+			if (args.Parameters.Count < 1)
+			{
+				args.Player.SendErrorMessage("Invalid syntax! Proper syntax: {0}accountinfo <username>", Specifier);
+				return;
+			}
+
+			string username = String.Join(" ", args.Parameters);
+			if (!string.IsNullOrWhiteSpace(username))
+			{
+				var user = TShock.Users.GetUserByName(username);
+				if (user != null)
+				{
+					DateTime LastSeen = DateTime.Parse(user.LastAccessed).ToLocalTime();
+					string Timezone = TimeZone.CurrentTimeZone.GetUtcOffset(DateTime.Now).Hours.ToString("+#;-#");
+
+					args.Player.SendSuccessMessage("{0}'s last login occured {1} {2} UTC{3}.", user.Name, LastSeen.ToShortDateString(),
+						LastSeen.ToShortTimeString(), Timezone);
+
+					if (args.Player.Group.HasPermission(Permissions.advaccountinfo))
+					{
+						List<string> KnownIps = JsonConvert.DeserializeObject<List<string>>(user.KnownIps);
+						string ip = KnownIps[KnownIps.Count - 1];
+						DateTime Registered = DateTime.Parse(user.Registered).ToLocalTime();
+
+						args.Player.SendSuccessMessage("{0}'s group is {1}.", user.Name, user.Group);
+						args.Player.SendSuccessMessage("{0}'s last known IP is {1}.", user.Name, ip);
+						args.Player.SendSuccessMessage("{0}'s register date is {1} {2} UTC{3}.", user.Name, Registered.ToShortDateString(), Registered.ToShortTimeString(), Timezone);
+					}
+				}
+				else
+					args.Player.SendErrorMessage("User {0} does not exist.", username);
+			}
+			else args.Player.SendErrorMessage("Invalid syntax! Proper syntax: {0}accountinfo <username>", Specifier);
 		}
 
 		private static void Kick(CommandArgs args)

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -388,6 +388,12 @@ namespace TShockAPI
 
 		[Description("Player can place banned tiles.")]
 		public static readonly string canusebannedtiles = "tshock.tiles.usebanned";
+
+		[Description("Player can check if a username is registered and see its last login time.")]
+		public static readonly string checkaccountinfo = "tshock.accountinfo.check";
+
+		[Description("Player can see advanced information about any user account.")]
+		public static readonly string advaccountinfo = "tshock.accountinfo.details";
 		/// <summary>
 		/// Lists all commands associated with a given permission
 		/// </summary>

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -412,8 +412,8 @@ namespace TShockAPI
 				KnownIps = JsonConvert.DeserializeObject<List<String>>(args.Player.User.KnownIps);
 			}
 
-			bool found = KnownIps.Any(s => s.Equals(args.Player.IP));
-			if (!found)
+			bool last = KnownIps.Last() == args.Player.IP;
+			if (!last)
 			{
 				if (KnownIps.Count == 100)
 				{
@@ -1467,8 +1467,14 @@ namespace TShockAPI
 		/// <param name="args">The CommandEventArgs object</param>
 		private void ServerHooks_OnCommand(CommandEventArgs args)
 		{
-			if (args.Handled || string.IsNullOrWhiteSpace(args.Command))
+			if (args.Handled)
 				return;
+
+			if (string.IsNullOrWhiteSpace(args.Command))
+			{
+				args.Handled = true;
+				return;
+			}
 
 			// Damn you ThreadStatic and Redigit
 			if (Main.rand == null)


### PR DESCRIPTION
I've implemented the /accountinfo command, which allows viewing _any_ user's information, as opposed to /userinfo. However, /userinfo remained untouched, for convenience of server admins.

/accountinfo has two permissions: tshock.accountinfo.check and tshock.accountinfo.details.
Having only the first permission will allow you to execute the command, and discover whetever a certain username is registered and if so, when its last login took place.
The second permission will allow you to see very detailed information about a user, including its last login time, group, last known IP and exact registration time.
The need for two permissions is dictated by the two cases this command can be used: for everyday use, and for admin purposes.
Everyday usage can be described as assisting new players in selecting a username for themselves. At the same time last login time may be used by regular players like a "last seen" command, allowing to see when their friends have last logged into the server.
Admin usage includes any other uses, such as IP-banning a hacker, finding out a certain user's group, finding out when a certain user account was registered. Exposing this information to regular users might be considered a security risk.

I've also discovered and fixed some counter-intuitive behavior in KnownIps object handling, which allowed a hacker to successfully evade offline bans on certain setups. This behavior may be considered an exploit.

More fixing has been applied for #1309, which became an issue after one of my previous pull requests. This should require no subsequent fixing.

Overall issues addressed by this: #901, #1309.