### PR TITLE
Update MotD file parsing to convert color formats into smart text.

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -4806,7 +4806,7 @@ namespace TShockAPI
 
 		private static void Motd(CommandArgs args)
 		{
-			TShock.Utils.ShowFileToUser(args.Player, "motd.txt");
+			TShock.Utils.ShowFileToUser(args.Player, FileTools.MotdPath);
 		}
 
 		private static void Rules(CommandArgs args)

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -4811,7 +4811,7 @@ namespace TShockAPI
 
 		private static void Rules(CommandArgs args)
 		{
-			TShock.Utils.ShowFileToUser(args.Player, "rules.txt");
+			TShock.Utils.ShowFileToUser(args.Player, FileTools.RulesPath);
 		}
 
 		private static void Whisper(CommandArgs args)

--- a/TShockAPI/FileTools.cs
+++ b/TShockAPI/FileTools.cs
@@ -40,7 +40,7 @@ namespace TShockAPI
 		/// </summary>
 		internal static string MotdPath
 		{
-			get { return Path.Combine(TShock.SavePath, "motd.txt"); }
+			get { return Path.Combine(TShock.SavePath, FileTools.MotdPath); }
 		}
 
 		/// <summary>

--- a/TShockAPI/FileTools.cs
+++ b/TShockAPI/FileTools.cs
@@ -40,7 +40,7 @@ namespace TShockAPI
 		/// </summary>
 		internal static string MotdPath
 		{
-			get { return Path.Combine(TShock.SavePath, FileTools.MotdPath); }
+			get { return Path.Combine(TShock.SavePath, "motd.txt"); }
 		}
 
 		/// <summary>

--- a/TShockAPI/Rest/RestManager.cs
+++ b/TShockAPI/Rest/RestManager.cs
@@ -280,7 +280,7 @@ namespace TShockAPI
 		[Token]
 		private object ServerMotd(RestRequestArgs args)
 		{
-			string motdFilePath = Path.Combine(TShock.SavePath, FileTools.MotdPath);
+			string motdFilePath = FileTools.MotdPath;
 			if (!File.Exists(motdFilePath))
 				return this.RestError("The motd.txt was not found.", "500");
 

--- a/TShockAPI/Rest/RestManager.cs
+++ b/TShockAPI/Rest/RestManager.cs
@@ -280,7 +280,7 @@ namespace TShockAPI
 		[Token]
 		private object ServerMotd(RestRequestArgs args)
 		{
-			string motdFilePath = Path.Combine(TShock.SavePath, "motd.txt");
+			string motdFilePath = Path.Combine(TShock.SavePath, FileTools.MotdPath);
 			if (!File.Exists(motdFilePath))
 				return this.RestError("The motd.txt was not found.", "500");
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1173,7 +1173,7 @@ namespace TShockAPI
 		{
 			if (args.Handled)
 				return;
-			
+
 			if (!Config.AllowCrimsonCreep && (args.Type == TileID.Dirt || args.Type == TileID.FleshWeeds
 				|| TileID.Sets.Crimson[args.Type]))
 			{
@@ -1577,7 +1577,7 @@ namespace TShockAPI
 			if (Config.DisplayIPToAdmins)
 				Utils.SendLogs(string.Format("{0} has joined. IP: {1}", player.Name, player.IP), Color.Blue);
 
-			Utils.ShowFileToUser(player, "motd.txt");
+			Utils.ShowFileToUser(player, FileTools.MotdPath);
 
 			string pvpMode = Config.PvPMode.ToLowerInvariant();
 			if (pvpMode == "always")

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -837,6 +837,8 @@ namespace TShockAPI
 			ComputeMaxStyles();
 			FixChestStacks();
 
+			Utils.UpgradeMotD();
+
 			if (Config.UseServerName)
 			{
 				Main.worldName = Config.ServerName;

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -50,7 +50,8 @@ namespace TShockAPI
 		/// <summary>instance - an instance of the utils class</summary>
 		private static readonly Utils instance = new Utils();
 
-		private Regex byteRegex = new Regex("%\\s*(?<r>\\d{1,3})\\s*,\\s*(?<g>\\d{1,3})\\s*,\\s*(?<b>\\d{1,3})\\s*%");
+		/// <summary> This regex will look for the old MotD format for colors and replace them with the new chat format. </summary>
+		private Regex motdColorRegex = new Regex(@"\%\s*(?<r>\d{1,3})\s*,\s*(?<g>\d{1,3})\s*,\s*(?<b>\d{1,3})\s*\%(?<text>((?!\%\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*\%).)*)");
 
 		/// <summary>Utils - Creates a utilities object.</summary>
 		private Utils() {}
@@ -193,7 +194,7 @@ namespace TShockAPI
 			TSPlayer.Server.SendMessage(log, color);
 			foreach (TSPlayer player in TShock.Players)
 			{
-				if (player != null && player != excludedPlayer && player.Active && player.HasPermission(Permissions.logs) && 
+				if (player != null && player != excludedPlayer && player.Active && player.HasPermission(Permissions.logs) &&
 						player.DisplayLogs && TShock.Config.DisableSpewLogs == false)
 					player.SendMessage(log, color);
 			}
@@ -502,7 +503,7 @@ namespace TShockAPI
 			}
 			return found;
 		}
-				
+
 				/// <summary>
 		/// Gets a prefix by ID or name
 		/// </summary>
@@ -557,7 +558,7 @@ namespace TShockAPI
 		}
 
 		/// <summary>
-		/// Stops the server after kicking all players with a reason message, and optionally saving the world then attempts to 
+		/// Stops the server after kicking all players with a reason message, and optionally saving the world then attempts to
 		/// restart it.
 		/// </summary>
 		/// <param name="save">bool perform a world save before stop (default: true)</param>
@@ -683,7 +684,7 @@ namespace TShockAPI
 							{
 									TShock.Bans.RemoveBan(ban.IP, false, false, false);
 							}
-							
+
 							return true;
 					}
 
@@ -699,7 +700,7 @@ namespace TShockAPI
 		{
 			string foo = "";
 			bool containsOldFormat = false;
-			using (var tr = new StreamReader(Path.Combine(TShock.SavePath, file)))
+			using (var tr = new StreamReader(file))
 			{
 				while ((foo = tr.ReadLine()) != null)
 				{
@@ -710,16 +711,38 @@ namespace TShockAPI
 
 					foo = foo.Replace("%map%", (TShock.Config.UseServerName ? TShock.Config.ServerName : Main.worldName));
 					foo = foo.Replace("%players%", String.Join(",", GetPlayers(false)));
-					if (byteRegex.IsMatch(foo) && !containsOldFormat)
+
+					string newFoo = ReplaceDeprecatedColorCodes(foo);
+					if (newFoo != foo && !containsOldFormat)
 					{
 						TShock.Log.ConsoleInfo($"You are using an old color format in file {file}.");
 						TShock.Log.ConsoleInfo("To send coloured text please use Terraria's inbuilt format of: [c/#hex:text].");
 						TShock.Log.ConsoleInfo("For example: [c/ff00aa:This is a message!].");
 						containsOldFormat = true;
 					}
+					foo = newFoo;
+
 					player.SendMessage(foo, Color.White);
 				}
 			}
+		}
+
+		/// <summary>
+		/// Returns a string with deprecated %###,###,###% formats replaced with the new chat format colors.
+		/// </summary>
+		/// <param name="input">The input string</param>
+		/// <returns>A replaced version of the input with the new chat color format.</returns>
+		private string ReplaceDeprecatedColorCodes(string input)
+		{
+			String tempString = input;
+			Match match = null;
+
+			while ((match = motdColorRegex.Match(tempString)).Success)
+			{
+				tempString = tempString.Replace(match.Groups[0].Value, String.Format("[c/{0:X2}{1:X2}{2:X2}:{3}]", Int32.Parse(match.Groups["r"].Value), Int32.Parse(match.Groups["g"].Value), Int32.Parse(match.Groups["b"].Value), match.Groups["text"]));
+			}
+
+			return tempString;
 		}
 
 		/// <summary>
@@ -874,7 +897,7 @@ namespace TShockAPI
 					int num;
 					if (!int.TryParse(sb.ToString(), out num))
 						return false;
-					
+
 					sb.Clear();
 					switch (str[i])
 					{

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -725,8 +725,10 @@ namespace TShockAPI
 												Int32.Parse(legacyColorMatch.Groups["b"].Value));
 						foo = foo.Replace(legacyColorMatch.Groups[0].Value, "");
 					}
-					string newFoo = ReplaceDeprecatedColorCodes(foo);
-					if (newFoo != foo && !containsOldFormat)
+
+					bool upgraded = false;
+					string newFoo = ReplaceDeprecatedColorCodes(foo, out upgraded);
+					if (upgraded && !containsOldFormat)
 					{
 						TShock.Log.ConsoleInfo($"You are using an old color format in file {file}.");
 						TShock.Log.ConsoleInfo("To send coloured text please use Terraria's inbuilt format of: [c/#hex:text].");
@@ -744,18 +746,67 @@ namespace TShockAPI
 		/// Returns a string with deprecated %###,###,###% formats replaced with the new chat format colors.
 		/// </summary>
 		/// <param name="input">The input string</param>
+		/// <param name="upgradedFormat">An out parameter that denotes if this line of text was upgraded.</param>
 		/// <returns>A replaced version of the input with the new chat color format.</returns>
-		private string ReplaceDeprecatedColorCodes(string input)
+		private string ReplaceDeprecatedColorCodes(string input, out bool upgradedFormat)
 		{
 			String tempString = input;
 			Match match = null;
+			bool uFormat = false;
 
 			while ((match = motdColorRegex.Match(tempString)).Success)
 			{
+				uFormat = true;
 				tempString = tempString.Replace(match.Groups[0].Value, String.Format("[c/{0:X2}{1:X2}{2:X2}:{3}]", Int32.Parse(match.Groups["r"].Value), Int32.Parse(match.Groups["g"].Value), Int32.Parse(match.Groups["b"].Value), match.Groups["text"]));
 			}
 
+			upgradedFormat = uFormat;
 			return tempString;
+		}
+
+		/// <summary>
+		/// Upgrades a legacy MotD file to the new terraria chat tags version.
+		/// </summary>
+		public void UpgradeMotD()
+		{
+			string foo = "";
+			StringBuilder motd = new StringBuilder();
+			bool informedOwner = false;
+			using (var tr = new StreamReader(FileTools.MotdPath))
+			{
+				Color lineColor;
+				while ((foo = tr.ReadLine()) != null)
+				{
+					lineColor = Color.White;
+					var legacyColorMatch = startOfLineColorRegex.Match(foo);
+					if (legacyColorMatch.Success)
+					{
+						lineColor = new Color(Int32.Parse(legacyColorMatch.Groups["r"].Value),
+												Int32.Parse(legacyColorMatch.Groups["g"].Value),
+												Int32.Parse(legacyColorMatch.Groups["b"].Value));
+						foo = foo.Replace(legacyColorMatch.Groups[0].Value, "");
+					}
+
+					bool upgraded = false;
+					string newFoo = ReplaceDeprecatedColorCodes(foo, out upgraded);
+					if (!informedOwner && upgraded)
+					{
+						informedOwner = true;
+						TShock.Log.ConsoleInfo("We have upgraded your MotD to the new format.  A backup has been created.");
+					}
+
+					if (lineColor != Color.White)
+						motd.Append(String.Format("%{0:d3},{1:d3},{2:d3}%", lineColor.R, lineColor.G, lineColor.B));
+
+					motd.AppendLine(newFoo);
+				}
+			}
+
+			if (informedOwner)
+			{
+				File.Copy(FileTools.MotdPath, String.Format("{0}_{1}.backup", FileTools.MotdPath, DateTime.Now.ToString("ddMMMyy_hhmmss")));
+				File.WriteAllText(FileTools.MotdPath, motd.ToString());
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
I have updated the Regex and logic to find and replace all text on a line with the smart text chat format.  This will replace all text that follows one of our old color formats until the next color format with smart text blocks.  We are still parsing a single line at a time, so the color does not carry over to the next line.  If we want to include that as a feature we certainly could make an improvement to keep track of the last color code used and apply that to all text until the next color code.

%255,000,000% This is text. -> [c/ff0000:This is text.]

This should address #1314.