### PR TITLE
Enable user to upload their data from when they join as SSC

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -298,6 +298,11 @@ namespace TShockAPI
 			{
 				HelpText = "Saves all serverside characters."
 			});
+			add(new Command(Permissions.uploaddata, UploadJoinData, "uploadssc")
+			{
+				HelpText = "Upload the account information when you joined the server as your Server Side Character data.",
+				AllowServer = false
+			});
 			add(new Command(Permissions.settempgroup, TempGroup, "tempgroup")
 			{
 				HelpText = "Temporarily sets another player's group."
@@ -1689,6 +1694,18 @@ namespace TShockAPI
 
 			TShock.CharacterDB.InsertPlayerData(matchedPlayer);
 			args.Player.SendSuccessMessage("SSC of player \"{0}\" has been overriden.", matchedPlayer.Name);
+		}
+
+		private static void UploadJoinData(CommandArgs args)
+		{
+			if (TShock.CharacterDB.InsertSpecificPlayerData(args.Player, args.Player.DataWhenJoined)) {
+				args.Player.DataWhenJoined.RestoreCharacter(args.Player);
+				args.Player.SendSuccessMessage("Your Join Data has been uploaded to the server.");
+			}
+			else
+			{
+				args.Player.SendErrorMessage("Failed to upload your data, please find an admin.");
+			}
 		}
 
 		private static void ForceHalloween(CommandArgs args)

--- a/TShockAPI/DB/CharacterManager.cs
+++ b/TShockAPI/DB/CharacterManager.cs
@@ -131,15 +131,15 @@ namespace TShockAPI.DB
 			string initialItems = String.Join("~", items.Take(NetItem.MaxInventory));
 			try
 			{
-				database.Query("INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, spawnX, spawnY, questsCompleted) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8);", 
+				database.Query("INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, spawnX, spawnY, questsCompleted) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8);",
 							   user.ID,
 							   TShock.ServerSideCharacterConfig.StartingHealth,
 							   TShock.ServerSideCharacterConfig.StartingHealth,
 							   TShock.ServerSideCharacterConfig.StartingMana,
-							   TShock.ServerSideCharacterConfig.StartingMana, 
-							   initialItems, 
-							   -1, 
-							   -1, 
+							   TShock.ServerSideCharacterConfig.StartingMana,
+							   initialItems,
+							   -1,
+							   -1,
 							   0);
 				return true;
 			}
@@ -159,7 +159,7 @@ namespace TShockAPI.DB
 		public bool InsertPlayerData(TSPlayer player)
 		{
 			PlayerData playerData = player.PlayerData;
-			
+
 			if (!player.IsLoggedIn)
 				return false;
 
@@ -217,6 +217,96 @@ namespace TShockAPI.DB
 				TShock.Log.Error(ex.ToString());
 			}
 
+			return false;
+		}
+
+		/// <summary>
+		/// Inserts a specific PlayerData into the SSC table for a player.
+		/// </summary>
+		/// <param name="player">The player to store the data for.</param>
+		/// <param name="data">The player data to store.</param>
+		/// <returns>If the command succeeds.</returns>
+		public bool InsertSpecificPlayerData(TSPlayer player, PlayerData data)
+		{
+			PlayerData playerData = data;
+
+			if (!player.IsLoggedIn)
+				return false;
+
+			if (player.HasPermission(Permissions.bypassssc))
+			{
+				TShock.Log.ConsoleInfo("Skipping SSC Backup for " + player.User.Name); // Debug code
+				return true;
+			}
+
+			if (!GetPlayerData(player, player.User.ID).exists)
+			{
+				try
+				{
+					database.Query(
+						"INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, extraSlot, spawnX, spawnY, skinVariant, hair, hairDye, hairColor, pantsColor, shirtColor, underShirtColor, shoeColor, hideVisuals, skinColor, eyeColor, questsCompleted) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19, @20);",
+						player.User.ID,
+						playerData.health,
+						playerData.maxHealth,
+						playerData.mana,
+						playerData.maxMana,
+						String.Join("~", playerData.inventory),
+						playerData.extraSlot,
+						playerData.spawnX,
+						playerData.spawnX,
+						playerData.skinVariant,
+						playerData.hair,
+						playerData.hairDye,
+						TShock.Utils.EncodeColor(playerData.hairColor),
+						TShock.Utils.EncodeColor(playerData.pantsColor),
+						TShock.Utils.EncodeColor(playerData.shirtColor),
+						TShock.Utils.EncodeColor(playerData.underShirtColor),
+						TShock.Utils.EncodeColor(playerData.shoeColor),
+						TShock.Utils.EncodeBoolArray(playerData.hideVisuals),
+						TShock.Utils.EncodeColor(playerData.skinColor),
+						TShock.Utils.EncodeColor(playerData.eyeColor),
+						playerData.questsCompleted);
+					return true;
+				}
+				catch (Exception ex)
+				{
+					TShock.Log.Error(ex.ToString());
+				}
+			}
+			else
+			{
+				try
+				{
+					database.Query(
+						"UPDATE tsCharacter SET Health = @0, MaxHealth = @1, Mana = @2, MaxMana = @3, Inventory = @4, spawnX = @6, spawnY = @7, hair = @8, hairDye = @9, hairColor = @10, pantsColor = @11, shirtColor = @12, underShirtColor = @13, shoeColor = @14, hideVisuals = @15, skinColor = @16, eyeColor = @17, questsCompleted = @18, skinVariant = @19, extraSlot = @20 WHERE Account = @5;",
+						playerData.health,
+						playerData.maxHealth,
+						playerData.mana,
+						playerData.maxMana,
+						String.Join("~", playerData.inventory),
+						player.User.ID,
+						playerData.spawnX,
+						playerData.spawnX,
+						playerData.skinVariant,
+						playerData.hair,
+						playerData.hairDye,
+						TShock.Utils.EncodeColor(playerData.hairColor),
+						TShock.Utils.EncodeColor(playerData.pantsColor),
+						TShock.Utils.EncodeColor(playerData.shirtColor),
+						TShock.Utils.EncodeColor(playerData.underShirtColor),
+						TShock.Utils.EncodeColor(playerData.shoeColor),
+						TShock.Utils.EncodeBoolArray(playerData.hideVisuals),
+						TShock.Utils.EncodeColor(playerData.skinColor),
+						TShock.Utils.EncodeColor(playerData.eyeColor),
+						playerData.questsCompleted,
+						playerData.extraSlot ?? 0);
+					return true;
+				}
+				catch (Exception ex)
+				{
+					TShock.Log.Error(ex.ToString());
+				}
+			}
 			return false;
 		}
 	}

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1506,6 +1506,8 @@ namespace TShockAPI
 		private static bool HandleConnecting(GetDataHandlerArgs args)
 		{
 			var user = TShock.Users.GetUserByName(args.Player.Name);
+			args.Player.DataWhenJoined = new PlayerData(args.Player);
+			args.Player.DataWhenJoined.CopyCharacter(args.Player);
 
 			if (user != null && !TShock.Config.DisableUUIDLogin)
 			{

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -88,6 +88,9 @@ namespace TShockAPI
 		[Description("User can save all the players SSI state.")]
 		public static readonly string savessc = "tshock.admin.savessi";
 
+		[Description("User can upload their joined character data as SSC data.")]
+		public static readonly string uploaddata = "tshock.ssc.upload";
+
 		[Description("User can elevate other users' groups temporarily.")]
 		public static readonly string settempgroup = "tshock.admin.tempgroup";
 

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -91,6 +91,9 @@ namespace TShockAPI
 		[Description("User can upload their joined character data as SSC data.")]
 		public static readonly string uploaddata = "tshock.ssc.upload";
 
+		[Description("User can upload other players join data to the SSC database.")]
+		public static readonly string uploadothersdata = "tshock.ssc.upload.others";
+
 		[Description("User can elevate other users' groups temporarily.")]
 		public static readonly string settempgroup = "tshock.admin.tempgroup";
 

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -73,7 +73,7 @@ namespace TShockAPI
 		/// The amount of tiles that the player has killed in the last second.
 		/// </summary>
 		public int TileKillThreshold { get; set; }
-		
+
 		/// <summary>
 		/// The amount of tiles the player has placed in the last second.
 		/// </summary>
@@ -113,10 +113,10 @@ namespace TShockAPI
 		/// A system to delay Remembered Position Teleports a few seconds
 		/// </summary>
 		public int RPPending = 0;
-		
+
 		public int sX = -1;
 		public int sY = -1;
-		
+
 		/// <summary>
 		/// A queue of tiles destroyed by the player for reverting.
 		/// </summary>
@@ -145,7 +145,7 @@ namespace TShockAPI
 		/// The player's temporary group.  This overrides the user's actual group.
 		/// </summary>
 		public Group tempGroup = null;
-		
+
 		public Timer tempGroupTimer;
 
 		private Group group = null;
@@ -158,7 +158,7 @@ namespace TShockAPI
 		public int Index { get; protected set; }
 
 		/// <summary>
-		/// The last time the player changed their team or pvp status.  
+		/// The last time the player changed their team or pvp status.
 		/// </summary>
 		public DateTime LastPvPTeamChange;
 
@@ -175,7 +175,7 @@ namespace TShockAPI
 		/// <summary>
 		/// A list of command callbacks indexed by the command they need to do.
 		/// </summary>
-		public Dictionary<string, Action<object>> AwaitingResponse;  
+		public Dictionary<string, Action<object>> AwaitingResponse;
 
 		public bool AwaitingName { get; set; }
 
@@ -332,14 +332,14 @@ namespace TShockAPI
 		/// Spawn protection message cool down.
 		/// </summary>
 		public long SPm = 1;
-			
+
 		/// <summary>
 		/// Permission to build message cool down.
 		/// </summary>
 		public long BPm = 1;
 
 		/// <summary>
-		/// The time in ms when the player has logged in.  
+		/// The time in ms when the player has logged in.
 		/// </summary>
 		public long LoginMS;
 
@@ -372,7 +372,7 @@ namespace TShockAPI
 		/// Contains data stored by plugins
 		/// </summary>
 		protected ConcurrentDictionary<string, object> data = new ConcurrentDictionary<string, object>();
-		
+
 		/// <summary>
 		/// Whether the player is a real, human, player on the server.
 		/// </summary>
@@ -592,6 +592,11 @@ namespace TShockAPI
 		}
 
 		/// <summary>
+		/// This contains the character data a player has when they join the server.
+		/// </summary>
+		public PlayerData DataWhenJoined { get; set; }
+
+		/// <summary>
 		/// Determines whether the player's storage contains the given key.
 		/// </summary>
 		/// <param name="key">Key to test.</param>
@@ -755,7 +760,7 @@ namespace TShockAPI
 		/// Spawns the player at his spawn point.
 		/// </summary>
 		public void Spawn()
-		{			
+		{
 			if (this.sX > 0 && this.sY > 0)
 			{
 				Spawn(this.sX, this.sY);
@@ -867,7 +872,7 @@ namespace TShockAPI
 		/// <returns>True or false, depending if the item passed the check or not.</returns>
 		public bool GiveItemCheck(int type, string name, int width, int height, int stack, int prefix = 0)
 		{
-			if ((TShock.Itembans.ItemIsBanned(name) && TShock.Config.PreventBannedItemSpawn) && 
+			if ((TShock.Itembans.ItemIsBanned(name) && TShock.Config.PreventBannedItemSpawn) &&
 				(TShock.Itembans.ItemIsBanned(name, this) || !TShock.Config.AllowAllowedGroupsToSpawnBannedItems))
 					return false;
 
@@ -983,7 +988,7 @@ namespace TShockAPI
 		}
 
 		/// <summary>
-		/// Sends a message with the specified color. 
+		/// Sends a message with the specified color.
 		/// </summary>
 		/// <param name="msg">The message.</param>
 		/// <param name="color">The message color.</param>


### PR DESCRIPTION
This will allow a user to run /uploadssc that will upload their characters data when they joined as their actual SSC data.  This is to address #1100.  This is controlled by a permission, tshock.ssc.upload.  It also adds the functionality to upload arbitrary playerdatas as their own, how much this was needed is unclear.  We could always remove that function and just use the existing method someway.  Let me know your suggestions~