### PR TITLE
Revert "Ensure IPs are > 0 otherwise the Linq will fail."

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -409,19 +409,17 @@ namespace TShockAPI
 				KnownIps = JsonConvert.DeserializeObject<List<String>>(args.Player.User.KnownIps);
 			}
 
-			if (KnownIps.Count > 0)
+			bool last = KnownIps.Last() == args.Player.IP;
+			if (!last)
 			{
-				bool last = KnownIps.Last() == args.Player.IP;
-				if (!last)
+				if (KnownIps.Count == 100)
 				{
-					if (KnownIps.Count == 100)
-					{
-						KnownIps.RemoveAt(0);
-					}
-
-					KnownIps.Add(args.Player.IP);
+					KnownIps.RemoveAt(0);
 				}
+
+				KnownIps.Add(args.Player.IP);
 			}
+
 			args.Player.User.KnownIps = JsonConvert.SerializeObject(KnownIps, Formatting.Indented);
 			Users.UpdateLogin(args.Player.User);
 		}
@@ -1174,7 +1172,7 @@ namespace TShockAPI
 		{
 			if (args.Handled)
 				return;
-
+			
 			if (!Config.AllowCrimsonCreep && (args.Type == TileID.Dirt || args.Type == TileID.FleshWeeds
 				|| TileID.Sets.Crimson[args.Type]))
 			{


### PR DESCRIPTION
Reverts NyxStudios/TShock#1320, per @Simon311's point that logic does indeed imply that KnownIPs will never be filled.