### PR TITLE
More Terraria dumps for NPC/Item/Projectile/Buff/Prefix

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -633,7 +633,7 @@ namespace TShockAPI
 							break;
 						}
 					case "-dump":
-					{
+						{
 							Utils.PrepareLangForDump();
 							Lang.setLang(true);
 							ConfigFile.DumpDescriptions();

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -633,11 +633,18 @@ namespace TShockAPI
 							break;
 						}
 					case "-dump":
-						{
+					{
+							Utils.PrepareLangForDump();
+							Lang.setLang(true);
 							ConfigFile.DumpDescriptions();
 							Permissions.DumpDescriptions();
 							ServerSideConfig.DumpDescriptions();
 							RestManager.DumpDescriptions();
+							Utils.DumpBuffs("BuffList.txt");
+							Utils.DumpItems("Items.txt");
+							Utils.DumpNPCs("NPCs.txt");
+							Utils.DumpProjectiles("Projectiles.txt");
+							Utils.DumpPrefixes("Prefixes.txt");
 							Environment.Exit(1);
 							break;
 						}

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -641,7 +641,10 @@ namespace TShockAPI
 							ServerSideConfig.DumpDescriptions();
 							RestManager.DumpDescriptions();
 							Utils.DumpBuffs("BuffList.txt");
-							Utils.DumpItems("Items.txt");
+							Utils.DumpItems("Items-1_0.txt", -48, 235);
+							Utils.DumpItems("Items-1_1.txt", 235, 604);
+							Utils.DumpItems("Items-1_2.txt", 604, 2749);
+							Utils.DumpItems("Items-1_3.txt", 2749, Main.maxItemTypes);
 							Utils.DumpNPCs("NPCs.txt");
 							Utils.DumpProjectiles("Projectiles.txt");
 							Utils.DumpPrefixes("Prefixes.txt");

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -1208,7 +1208,7 @@ namespace TShockAPI
 			File.WriteAllText(path, buffer.ToString());
 		}
 
-		public void DumpItems(string path)
+		public void DumpItems(string path, int start, int end)
 		{
 			Main.player[Main.myPlayer] = new Player();
 			StringBuilder buffer = new StringBuilder();
@@ -1219,7 +1219,7 @@ namespace TShockAPI
 			buffer.AppendLine("    \"h-2\": \"Tooltip 2\",");
 
 			List<object[]> elements = new List<object[]>();
-			for (int i = -48; i < Main.maxItemTypes; i++)
+			for (int i = start; i < end; i++)
 			{
 				Item item = new Item();
 				item.netDefaults(i);

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -1166,5 +1166,155 @@ namespace TShockAPI
 
 			return points;
 		}
+
+		internal void PrepareLangForDump()
+		{
+			for(int i = 0; i < Main.recipe.Length; i++)
+				Main.recipe[i] = new Recipe();
+		}
+
+		public void DumpBuffs(string path)
+		{
+			StringBuilder buffer = new StringBuilder();
+			buffer.AppendLine("[block: parameters]").AppendLine("{").AppendLine("\t\"data\": {");
+			buffer.AppendLine("\t\t\"h-0\":\"ID\",");
+			buffer.AppendLine("\t\t\"h-1\":\"Name\",");
+			buffer.AppendLine("\t\t\"h-2\":\"Description\",");
+
+			var row = 0;
+			for(int i = 0; i < Main.maxBuffTypes; i++)
+			{
+				if (!String.IsNullOrEmpty(Main.buffName[i]))
+				{
+					if (row > 0)
+						buffer.AppendLine(",");
+
+					buffer.AppendLine(String.Format("\t\t\"{0}-0\": \"{1}\",", row, i));
+					buffer.AppendLine(String.Format("\t\t\"{0}-1\": \"{1}\",", row, Main.buffName[i]));
+					buffer.Append(String.Format("\t\t\"{0}-2\": \"{1}\"", row++, Main.buffTip[i]));
+				}
+			}
+
+			buffer.AppendLine();
+			buffer.AppendLine("\t}").AppendLine("}");
+
+			File.WriteAllText(path, buffer.ToString());
+		}
+
+		public void DumpItems(string path)
+		{
+			Main.player[Main.myPlayer] = new Player();
+			StringBuilder buffer = new StringBuilder();
+			buffer.AppendLine("[block: parameters]").AppendLine("{").AppendLine("\t\"data\": {");
+			buffer.AppendLine("\t\t\"h-0\":\"ID\",");
+			buffer.AppendLine("\t\t\"h-1\":\"Name\",");
+			buffer.AppendLine("\t\t\"h-2\":\"Tooltip\",");
+			buffer.AppendLine("\t\t\"h-2\":\"Tooltip 2\",");
+
+			var row = 0;
+			for (int i = -48; i < Main.maxItemTypes; i++)
+			{
+				Item item = new Item();
+				item.netDefaults(i);
+				if (!String.IsNullOrEmpty(item.name))
+				{
+					if (row > 0)
+						buffer.AppendLine(",");
+
+					buffer.AppendLine(String.Format("\t\t\"{0}-0\": \"{1}\",", row, i));
+					buffer.AppendLine(String.Format("\t\t\"{0}-1\": \"{1}\",", row, item.name));
+					buffer.AppendLine(String.Format("\t\t\"{0}-1\": \"{1}\",", row, item.toolTip));
+					buffer.Append(String.Format("\t\t\"{0}-1\": \"{1}\"", row++, item.toolTip2));
+				}
+			}
+			buffer.AppendLine();
+			buffer.AppendLine("\t}").AppendLine("}");
+
+			File.WriteAllText(path, buffer.ToString());
+		}
+
+		public void DumpNPCs(string path)
+		{
+			StringBuilder buffer = new StringBuilder();
+			buffer.AppendLine("[block: parameters]").AppendLine("{").AppendLine("\t\"data\": {");
+			buffer.AppendLine("\t\t\"h-0\":\"ID\",");
+			buffer.AppendLine("\t\t\"h-1\":\"Name\",");
+			buffer.AppendLine("\t\t\"h-2\":\"Display Name\",");
+
+			var row = 0;
+			for (int i = -65; i < Main.maxNPCTypes; i++)
+			{
+				NPC npc = new NPC();
+				npc.netDefaults(i);
+				if (!String.IsNullOrEmpty(npc.name))
+				{
+					if (row > 0)
+						buffer.AppendLine(",");
+
+					buffer.AppendLine(String.Format("\t\t\"{0}-0\": \"{1}\",", row, i));
+					buffer.AppendLine(String.Format("\t\t\"{0}-1\": \"{1}\",", row, npc.name));
+					buffer.Append(String.Format("\t\t\"{0}-1\": \"{1}\"", row++, npc.displayName));
+				}
+			}
+			buffer.AppendLine();
+			buffer.AppendLine("\t}").AppendLine("}");
+
+			File.WriteAllText(path, buffer.ToString());
+		}
+
+		public void DumpProjectiles(string path)
+		{
+			Main.rand = new Random();
+			StringBuilder buffer = new StringBuilder();
+			buffer.AppendLine("[block: parameters]").AppendLine("{").AppendLine("\t\"data\": {");
+			buffer.AppendLine("\t\t\"h-0\":\"ID\",");
+			buffer.AppendLine("\t\t\"h-1\":\"Name\",");
+
+			var row = 0;
+			for (int i = 0; i < Main.maxProjectileTypes; i++)
+			{
+				Projectile projectile = new Projectile();
+				projectile.SetDefaults(i);
+				if (!String.IsNullOrEmpty(projectile.name))
+				{
+					if (row > 0)
+						buffer.AppendLine(",");
+
+					buffer.AppendLine(String.Format("\t\t\"{0}-0\": \"{1}\",", row, i));
+					buffer.Append(String.Format("\t\t\"{0}-1\": \"{1}\"", row++, projectile.name));
+				}
+			}
+			buffer.AppendLine();
+			buffer.AppendLine("\t}").AppendLine("}");
+
+			File.WriteAllText(path, buffer.ToString());
+		}
+
+		public void DumpPrefixes(string path)
+		{
+			StringBuilder buffer = new StringBuilder();
+			buffer.AppendLine("[block: parameters]").AppendLine("{").AppendLine("\t\"data\": {");
+			buffer.AppendLine("\t\t\"h-0\":\"ID\",");
+			buffer.AppendLine("\t\t\"h-1\":\"Name\",");
+
+			var row = 0;
+			for (int i = 0; i < Item.maxPrefixes; i++)
+			{
+				string prefix = Lang.prefix[i];
+
+				if (!String.IsNullOrEmpty(prefix))
+				{
+					if (row > 0)
+						buffer.AppendLine(",");
+
+					buffer.AppendLine(String.Format("\t\t\"{0}-0\": \"{1}\",", row, i));
+					buffer.Append(String.Format("\t\t\"{0}-1\": \"{1}\"", row++, prefix));
+				}
+			}
+			buffer.AppendLine();
+			buffer.AppendLine("\t}").AppendLine("}");
+
+			File.WriteAllText(path, buffer.ToString());
+		}
 	}
 }

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -1212,11 +1212,12 @@ namespace TShockAPI
 		{
 			Main.player[Main.myPlayer] = new Player();
 			StringBuilder buffer = new StringBuilder();
+			Regex newLine = new Regex(@"\n");
 			buffer.AppendLine("[block:parameters]").AppendLine("{").AppendLine("  \"data\": {");
 			buffer.AppendLine("    \"h-0\": \"ID\",");
 			buffer.AppendLine("    \"h-1\": \"Name\",");
 			buffer.AppendLine("    \"h-2\": \"Tooltip\",");
-			buffer.AppendLine("    \"h-2\": \"Tooltip 2\",");
+			buffer.AppendLine("    \"h-3\": \"Tooltip 2\",");
 
 			List<object[]> elements = new List<object[]>();
 			for (int i = start; i < end; i++)
@@ -1225,7 +1226,11 @@ namespace TShockAPI
 				item.netDefaults(i);
 				if (!String.IsNullOrEmpty(item.name))
 				{
-					object[] element = new object[] { i, item.name, item.toolTip, item.toolTip2 };
+					object[] element = new object[] { i,
+													  newLine.Replace(item.name, @" "),
+													  newLine.Replace(item.toolTip, @" "),
+													  newLine.Replace(item.toolTip2, @" ")
+													};
 					elements.Add(element);
 				}
 			}

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -1176,27 +1177,33 @@ namespace TShockAPI
 		public void DumpBuffs(string path)
 		{
 			StringBuilder buffer = new StringBuilder();
-			buffer.AppendLine("[block: parameters]").AppendLine("{").AppendLine("\t\"data\": {");
-			buffer.AppendLine("\t\t\"h-0\":\"ID\",");
-			buffer.AppendLine("\t\t\"h-1\":\"Name\",");
-			buffer.AppendLine("\t\t\"h-2\":\"Description\",");
+			buffer.AppendLine("[block:parameters]").AppendLine("{").AppendLine("  \"data\": {");
+			buffer.AppendLine("    \"h-0\": \"ID\",");
+			buffer.AppendLine("    \"h-1\": \"Name\",");
+			buffer.AppendLine("    \"h-2\": \"Description\",");
 
-			var row = 0;
-			for(int i = 0; i < Main.maxBuffTypes; i++)
+			List<object[]> elements = new List<object[]>();
+			for (int i = 0; i < Main.maxBuffTypes; i++)
 			{
 				if (!String.IsNullOrEmpty(Main.buffName[i]))
 				{
-					if (row > 0)
-						buffer.AppendLine(",");
-
-					buffer.AppendLine(String.Format("\t\t\"{0}-0\": \"{1}\",", row, i));
-					buffer.AppendLine(String.Format("\t\t\"{0}-1\": \"{1}\",", row, Main.buffName[i]));
-					buffer.Append(String.Format("\t\t\"{0}-2\": \"{1}\"", row++, Main.buffTip[i]));
+					object[] element = new object[] { i, Main.buffName[i], Main.buffTip[i] };
+					elements.Add(element);
 				}
 			}
 
+			var rows = elements.Count;
+			var columns = 0;
+			if (rows > 0)
+			{
+				columns = elements[0].Length;
+			}
+			OutputElementsForDump(buffer, elements, rows, columns);
+
 			buffer.AppendLine();
-			buffer.AppendLine("\t}").AppendLine("}");
+			buffer.AppendLine("  },");
+			buffer.AppendLine(String.Format("  \"cols\": {0},", columns)).AppendLine(String.Format("  \"rows\": {0}", rows));
+			buffer.AppendLine("}").Append("[/block]");
 
 			File.WriteAllText(path, buffer.ToString());
 		}
@@ -1205,30 +1212,36 @@ namespace TShockAPI
 		{
 			Main.player[Main.myPlayer] = new Player();
 			StringBuilder buffer = new StringBuilder();
-			buffer.AppendLine("[block: parameters]").AppendLine("{").AppendLine("\t\"data\": {");
-			buffer.AppendLine("\t\t\"h-0\":\"ID\",");
-			buffer.AppendLine("\t\t\"h-1\":\"Name\",");
-			buffer.AppendLine("\t\t\"h-2\":\"Tooltip\",");
-			buffer.AppendLine("\t\t\"h-2\":\"Tooltip 2\",");
+			buffer.AppendLine("[block:parameters]").AppendLine("{").AppendLine("  \"data\": {");
+			buffer.AppendLine("    \"h-0\": \"ID\",");
+			buffer.AppendLine("    \"h-1\": \"Name\",");
+			buffer.AppendLine("    \"h-2\": \"Tooltip\",");
+			buffer.AppendLine("    \"h-2\": \"Tooltip 2\",");
 
-			var row = 0;
+			List<object[]> elements = new List<object[]>();
 			for (int i = -48; i < Main.maxItemTypes; i++)
 			{
 				Item item = new Item();
 				item.netDefaults(i);
 				if (!String.IsNullOrEmpty(item.name))
 				{
-					if (row > 0)
-						buffer.AppendLine(",");
-
-					buffer.AppendLine(String.Format("\t\t\"{0}-0\": \"{1}\",", row, i));
-					buffer.AppendLine(String.Format("\t\t\"{0}-1\": \"{1}\",", row, item.name));
-					buffer.AppendLine(String.Format("\t\t\"{0}-1\": \"{1}\",", row, item.toolTip));
-					buffer.Append(String.Format("\t\t\"{0}-1\": \"{1}\"", row++, item.toolTip2));
+					object[] element = new object[] { i, item.name, item.toolTip, item.toolTip2 };
+					elements.Add(element);
 				}
 			}
+
+			var rows = elements.Count;
+			var columns = 0;
+			if (rows > 0)
+			{
+				columns = elements[0].Length;
+			}
+			OutputElementsForDump(buffer, elements, rows, columns);
+
 			buffer.AppendLine();
-			buffer.AppendLine("\t}").AppendLine("}");
+			buffer.AppendLine("  },");
+			buffer.AppendLine(String.Format("  \"cols\": {0},", columns)).AppendLine(String.Format("  \"rows\": {0}", rows));
+			buffer.AppendLine("}").Append("[/block]");
 
 			File.WriteAllText(path, buffer.ToString());
 		}
@@ -1236,28 +1249,35 @@ namespace TShockAPI
 		public void DumpNPCs(string path)
 		{
 			StringBuilder buffer = new StringBuilder();
-			buffer.AppendLine("[block: parameters]").AppendLine("{").AppendLine("\t\"data\": {");
-			buffer.AppendLine("\t\t\"h-0\":\"ID\",");
-			buffer.AppendLine("\t\t\"h-1\":\"Name\",");
-			buffer.AppendLine("\t\t\"h-2\":\"Display Name\",");
+			buffer.AppendLine("[block:parameters]").AppendLine("{").AppendLine("  \"data\": {");
+			buffer.AppendLine("    \"h-0\": \"ID\",");
+			buffer.AppendLine("    \"h-1\": \"Name\",");
+			buffer.AppendLine("    \"h-2\": \"Display Name\",");
 
-			var row = 0;
+			List<object[]> elements = new List<object[]>();
 			for (int i = -65; i < Main.maxNPCTypes; i++)
 			{
 				NPC npc = new NPC();
 				npc.netDefaults(i);
 				if (!String.IsNullOrEmpty(npc.name))
 				{
-					if (row > 0)
-						buffer.AppendLine(",");
-
-					buffer.AppendLine(String.Format("\t\t\"{0}-0\": \"{1}\",", row, i));
-					buffer.AppendLine(String.Format("\t\t\"{0}-1\": \"{1}\",", row, npc.name));
-					buffer.Append(String.Format("\t\t\"{0}-1\": \"{1}\"", row++, npc.displayName));
+					object[] element = new object[] { i, npc.name, npc.displayName };
+					elements.Add(element);
 				}
 			}
+
+			var rows = elements.Count;
+			var columns = 0;
+			if (rows > 0)
+			{
+				columns = elements[0].Length;
+			}
+			OutputElementsForDump(buffer, elements, rows, columns);
+
 			buffer.AppendLine();
-			buffer.AppendLine("\t}").AppendLine("}");
+			buffer.AppendLine("  },");
+			buffer.AppendLine(String.Format("  \"cols\": {0},", columns)).AppendLine(String.Format("  \"rows\": {0}", rows));
+			buffer.AppendLine("}").Append("[/block]");
 
 			File.WriteAllText(path, buffer.ToString());
 		}
@@ -1266,26 +1286,34 @@ namespace TShockAPI
 		{
 			Main.rand = new Random();
 			StringBuilder buffer = new StringBuilder();
-			buffer.AppendLine("[block: parameters]").AppendLine("{").AppendLine("\t\"data\": {");
-			buffer.AppendLine("\t\t\"h-0\":\"ID\",");
-			buffer.AppendLine("\t\t\"h-1\":\"Name\",");
+			buffer.AppendLine("[block:parameters]").AppendLine("{").AppendLine("  \"data\": {");
+			buffer.AppendLine("    \"h-0\": \"ID\",");
+			buffer.AppendLine("    \"h-1\": \"Name\",");
 
-			var row = 0;
+			List<object[]> elements = new List<object[]>();
 			for (int i = 0; i < Main.maxProjectileTypes; i++)
 			{
 				Projectile projectile = new Projectile();
 				projectile.SetDefaults(i);
 				if (!String.IsNullOrEmpty(projectile.name))
 				{
-					if (row > 0)
-						buffer.AppendLine(",");
-
-					buffer.AppendLine(String.Format("\t\t\"{0}-0\": \"{1}\",", row, i));
-					buffer.Append(String.Format("\t\t\"{0}-1\": \"{1}\"", row++, projectile.name));
+					object[] element = new object[] { i, projectile.name };
+					elements.Add(element);
 				}
 			}
+
+			var rows = elements.Count;
+			var columns = 0;
+			if (rows > 0)
+			{
+				columns = elements[0].Length;
+			}
+			OutputElementsForDump(buffer, elements, rows, columns);
+
 			buffer.AppendLine();
-			buffer.AppendLine("\t}").AppendLine("}");
+			buffer.AppendLine("  },");
+			buffer.AppendLine(String.Format("  \"cols\": {0},", columns)).AppendLine(String.Format("  \"rows\": {0}", rows));
+			buffer.AppendLine("}").Append("[/block]");
 
 			File.WriteAllText(path, buffer.ToString());
 		}
@@ -1293,28 +1321,53 @@ namespace TShockAPI
 		public void DumpPrefixes(string path)
 		{
 			StringBuilder buffer = new StringBuilder();
-			buffer.AppendLine("[block: parameters]").AppendLine("{").AppendLine("\t\"data\": {");
-			buffer.AppendLine("\t\t\"h-0\":\"ID\",");
-			buffer.AppendLine("\t\t\"h-1\":\"Name\",");
+			buffer.AppendLine("[block:parameters]").AppendLine("{").AppendLine("  \"data\": {");
+			buffer.AppendLine("    \"h-0\": \"ID\",");
+			buffer.AppendLine("    \"h-1\": \"Name\",");
 
-			var row = 0;
+			List<object[]> elements = new List<object[]>();
 			for (int i = 0; i < Item.maxPrefixes; i++)
 			{
 				string prefix = Lang.prefix[i];
 
 				if (!String.IsNullOrEmpty(prefix))
 				{
-					if (row > 0)
-						buffer.AppendLine(",");
-
-					buffer.AppendLine(String.Format("\t\t\"{0}-0\": \"{1}\",", row, i));
-					buffer.Append(String.Format("\t\t\"{0}-1\": \"{1}\"", row++, prefix));
+					object[] element = new object[] {i, prefix};
+					elements.Add(element);
 				}
 			}
+
+			var rows = elements.Count;
+			var columns = 0;
+			if (rows > 0)
+			{
+				columns = elements[0].Length;
+			}
+			OutputElementsForDump(buffer, elements, rows, columns);
+
 			buffer.AppendLine();
-			buffer.AppendLine("\t}").AppendLine("}");
+			buffer.AppendLine("  },");
+			buffer.AppendLine(String.Format("  \"cols\": {0},", columns)).AppendLine(String.Format("  \"rows\": {0}", rows));
+			buffer.AppendLine("}").Append("[/block]");
 
 			File.WriteAllText(path, buffer.ToString());
+		}
+
+		private void OutputElementsForDump(StringBuilder buffer, List<object[]> elements, int rows, int columns)
+		{
+			if (rows > 0)
+			{
+				columns = elements[0].Length;
+				for (int i = 0; i < columns; i++)
+				{
+					for (int j = 0; j < rows; j++)
+					{
+						buffer.Append(String.Format("    \"{0}-{1}\": \"{2}\"", j, i, elements[j][i]));
+						if (j != rows - 1 || i != columns - 1)
+							buffer.AppendLine(",");
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
I noticed a bunch of chat in Slack about manually (?) going through and updating all the lists of documentation on readme.io  This seemed absolutely silly and a painful process going forward.  TShock already has the ability to dump the configs (see https://github.com/NyxStudios/TShock/blob/general-devel/scripts/test_release.py#L29).  Using the same logic, I have added some of the more common Terraria data dumps to this switch.  Some of them require fine tuning Terraria since this runs before the server is in a fully usable state.

See attached for samples.

[dumps.zip](https://github.com/NyxStudios/TShock/files/551975/dumps.zip)
