### PR TITLE
Refactor some of the mess that is NetItem and PlayerData.

### DIFF
--- a/TShockAPI/NetItem.cs
+++ b/TShockAPI/NetItem.cs
@@ -76,6 +76,15 @@ namespace TShockAPI
 		/// </summary>
 		public static readonly int MaxInventory = InventorySlots + ArmorSlots + DyeSlots + MiscEquipSlots + MiscDyeSlots + PiggySlots + SafeSlots + ForgeSlots + 1;
 
+		public static readonly Tuple<int, int> InventoryIndex = new Tuple<int, int>(0, InventorySlots);
+		public static readonly Tuple<int, int> ArmorIndex = new Tuple<int, int>(InventoryIndex.Item2, InventoryIndex.Item2 + ArmorSlots);
+		public static readonly Tuple<int, int> DyeIndex = new Tuple<int, int>(ArmorIndex.Item2, ArmorIndex.Item2 + DyeSlots);
+		public static readonly Tuple<int, int> MiscEquipIndex = new Tuple<int, int>(DyeIndex.Item2, DyeIndex.Item2 + MiscEquipSlots);
+		public static readonly Tuple<int, int> MiscDyeIndex = new Tuple<int, int>(MiscEquipIndex.Item2, MiscEquipIndex.Item2 + MiscDyeSlots);
+		public static readonly Tuple<int, int> PiggyIndex = new Tuple<int, int>(MiscDyeIndex.Item2, MiscDyeIndex.Item2 + PiggySlots);
+		public static readonly Tuple<int, int> SafeIndex = new Tuple<int, int>(PiggyIndex.Item2, PiggyIndex.Item2 + SafeSlots);
+		public static readonly Tuple<int, int> ForgeIndex = new Tuple<int, int>(SafeIndex.Item2, SafeIndex.Item2 + ForgeSlots);
+
 		[JsonProperty("netID")]
 		private int _netId;
 		[JsonProperty("prefix")]

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -123,64 +123,51 @@ namespace TShockAPI
 
 			for (int i = 0; i < NetItem.MaxInventory; i++)
 			{
-				if (i < NetItem.InventorySlots)
+				if (i < NetItem.InventoryIndex.Item2)
 				{
 					//0-58
 					this.inventory[i] = (NetItem)inventory[i];
 				}
-				else if (i < NetItem.InventorySlots + NetItem.ArmorSlots)
+				else if (i < NetItem.ArmorIndex.Item2)
 				{
 					//59-78
-					var index = i - NetItem.InventorySlots;
+					var index = i - NetItem.ArmorIndex.Item1;
 					this.inventory[i] = (NetItem)armor[index];
 				}
-				else if (i < NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots)
+				else if (i < NetItem.DyeIndex.Item2)
 				{
 					//79-88
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots);
+					var index = i - NetItem.DyeIndex.Item1;
 					this.inventory[i] = (NetItem)dye[index];
 				}
-				else if (i <
-					NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots)
+				else if (i < NetItem.MiscEquipIndex.Item2)
 				{
 					//89-93
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots);
+					var index = i - NetItem.MiscEquipIndex.Item1;
 					this.inventory[i] = (NetItem)miscEqups[index];
 				}
-				else if (i <
-					NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots
-					+ NetItem.MiscDyeSlots)
+				else if (i < NetItem.MiscDyeIndex.Item2)
 				{
 					//93-98
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots
-						+ NetItem.MiscEquipSlots);
+					var index = i - NetItem.MiscDyeIndex.Item1;
 					this.inventory[i] = (NetItem)miscDyes[index];
 				}
-				else if (i <
-				   NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots +
-				   NetItem.MiscDyeSlots + NetItem.PiggySlots)
+				else if (i < NetItem.PiggyIndex.Item2)
 				{
 					//98-138
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots
-						+ NetItem.MiscEquipSlots + NetItem.MiscDyeSlots);
+					var index = i - NetItem.PiggyIndex.Item1;
 					this.inventory[i] = (NetItem)piggy[index];
 				}
-				else if (i <
-					NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots +
-					NetItem.MiscDyeSlots + NetItem.PiggySlots + NetItem.SafeSlots)
+				else if (i < NetItem.SafeIndex.Item2)
 				{
 					//138-178
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots
-						+ NetItem.MiscEquipSlots + NetItem.MiscDyeSlots + NetItem.PiggySlots);
+					var index = i - NetItem.SafeIndex.Item1;
 					this.inventory[i] = (NetItem)safe[index];
 				}
-				else if (i <
-					NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots +
-					NetItem.MiscDyeSlots + NetItem.PiggySlots + NetItem.SafeSlots + NetItem.ForgeSlots)
+				else if (i < NetItem.ForgeIndex.Item2)
 				{
 					//179-219
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots
-						+ NetItem.MiscEquipSlots + NetItem.MiscDyeSlots + NetItem.PiggySlots);
+					var index = i - NetItem.ForgeIndex.Item1;
 					this.inventory[i] = (NetItem)forge[index];
 				}
 				else


### PR DESCRIPTION
NetItem and PlayerData are more sane.  

Can not reproduce the SSC corruption with this.

Steps taken:
1) Enable SSC
2) Register Character
3) Log in to character
4) Give items and fill random slots of inventory.
5) Fill random slots of piggy/safe/forge.
6) Log out
7) Log in
8) Check inventories.

Everything was as expected.

This probably fixes #1340 and #1337, as neither occur with this build.