### PR TITLE
Catch and log on linux socket read

### DIFF
--- a/TShockAPI/Sockets/LinuxTcpSocket.cs
+++ b/TShockAPI/Sockets/LinuxTcpSocket.cs
@@ -73,7 +73,20 @@ namespace TShockAPI.Sockets
 		private void ReadCallback(IAsyncResult result)
 		{
 			Tuple<SocketReceiveCallback, object> tuple = (Tuple<SocketReceiveCallback, object>)result.AsyncState;
-			tuple.Item1(tuple.Item2, this._connection.GetStream().EndRead(result));
+
+			try
+			{
+				tuple.Item1(tuple.Item2, this._connection.GetStream().EndRead(result));
+			}
+			catch (InvalidOperationException)
+			{
+				// This is common behaviour during client disconnects
+				((ISocket)this).Close();
+			}
+			catch (Exception ex)
+			{
+				TShock.Log.Error(ex.ToString());
+			}
 		}
 
 		private void SendCallback(IAsyncResult result)


### PR DESCRIPTION
This should prevent the following exception from crashing the server:
```
2016-12-12 20:41:35 - TShock: ERROR: System.InvalidOperationException: The operation is not allowed on non-connected sockets.
   at System.Net.Sockets.TcpClient.GetStream()
   at TShockAPI.Sockets.LinuxTcpSocket.ReadCallback(IAsyncResult result)
   at System.Net.LazyAsyncResult.Complete(IntPtr userToken)
   at System.Net.ContextAwareResult.CompleteCallback(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Net.ContextAwareResult.Complete(IntPtr userToken)
   at System.Net.LazyAsyncResult.ProtectedInvokeCallback(Object result, IntPtr userToken)
   at System.Net.Sockets.BaseOverlappedAsyncResult.CompletionPortCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped)
   at System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* pOVERLAP)
```
Would appreciate it if the person who reported this could test it -- @Zaicon.