### PR TITLE
Fix Prefixes in the Forge not being correct.

### DIFF
--- a/TShockAPI/NetItem.cs
+++ b/TShockAPI/NetItem.cs
@@ -72,6 +72,11 @@ namespace TShockAPI
 		public static readonly int MiscDyeSlots = MiscEquipSlots;
 
 		/// <summary>
+		/// 1 - The number of trash can slots.
+		/// </summary>
+		public static readonly int TrashSlots = 1;
+
+		/// <summary>
 		/// 180 - The inventory size (inventory, held item, armour, dies, coins, ammo, piggy, safe, and trash)
 		/// </summary>
 		public static readonly int MaxInventory = InventorySlots + ArmorSlots + DyeSlots + MiscEquipSlots + MiscDyeSlots + PiggySlots + SafeSlots + ForgeSlots + 1;
@@ -83,7 +88,8 @@ namespace TShockAPI
 		public static readonly Tuple<int, int> MiscDyeIndex = new Tuple<int, int>(MiscEquipIndex.Item2, MiscEquipIndex.Item2 + MiscDyeSlots);
 		public static readonly Tuple<int, int> PiggyIndex = new Tuple<int, int>(MiscDyeIndex.Item2, MiscDyeIndex.Item2 + PiggySlots);
 		public static readonly Tuple<int, int> SafeIndex = new Tuple<int, int>(PiggyIndex.Item2, PiggyIndex.Item2 + SafeSlots);
-		public static readonly Tuple<int, int> ForgeIndex = new Tuple<int, int>(SafeIndex.Item2, SafeIndex.Item2 + ForgeSlots);
+		public static readonly Tuple<int, int> TrashIndex = new Tuple<int, int>(SafeIndex.Item2, SafeIndex.Item2 + TrashSlots);
+		public static readonly Tuple<int, int> ForgeIndex = new Tuple<int, int>(TrashIndex.Item2, TrashIndex.Item2 + ForgeSlots);
 
 		[JsonProperty("netID")]
 		private int _netId;

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -164,16 +164,17 @@ namespace TShockAPI
 					var index = i - NetItem.SafeIndex.Item1;
 					this.inventory[i] = (NetItem)safe[index];
 				}
-				else if (i < NetItem.ForgeIndex.Item2)
+				else if (i < NetItem.TrashIndex.Item2)
 				{
 					//179-219
-					var index = i - NetItem.ForgeIndex.Item1;
-					this.inventory[i] = (NetItem)forge[index];
+					this.inventory[i] = (NetItem)trash;
 				}
 				else
 				{
 					//220
-					this.inventory[i] = (NetItem)trash;
+					var index = i - NetItem.ForgeIndex.Item1;
+					this.inventory[i] = (NetItem)forge[index];
+					
 				}
 			}
 		}
@@ -226,7 +227,7 @@ namespace TShockAPI
 
 			for (int i = 0; i < NetItem.MaxInventory; i++)
 			{
-				if (i < NetItem.InventorySlots)
+				if (i < NetItem.InventoryIndex.Item2)
 				{
 					//0-58
 					player.TPlayer.inventory[i].netDefaults(this.inventory[i].NetId);
@@ -237,10 +238,10 @@ namespace TShockAPI
 						player.TPlayer.inventory[i].prefix = this.inventory[i].PrefixId;
 					}
 				}
-				else if (i < NetItem.InventorySlots + NetItem.ArmorSlots)
+				else if (i < NetItem.ArmorIndex.Item2)
 				{
 					//59-78
-					var index = i - NetItem.InventorySlots;
+					var index = i - NetItem.ArmorIndex.Item1;
 					player.TPlayer.armor[index].netDefaults(this.inventory[i].NetId);
 
 					if (player.TPlayer.armor[index].netID != 0)
@@ -249,10 +250,10 @@ namespace TShockAPI
 						player.TPlayer.armor[index].prefix = (byte)this.inventory[i].PrefixId;
 					}
 				}
-				else if (i < NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots)
+				else if (i < NetItem.DyeIndex.Item2)
 				{
 					//79-88
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots);
+					var index = i - NetItem.DyeIndex.Item1;
 					player.TPlayer.dye[index].netDefaults(this.inventory[i].NetId);
 
 					if (player.TPlayer.dye[index].netID != 0)
@@ -261,11 +262,10 @@ namespace TShockAPI
 						player.TPlayer.dye[index].prefix = (byte)this.inventory[i].PrefixId;
 					}
 				}
-				else if (i <
-					NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots)
+				else if (i < NetItem.MiscEquipIndex.Item2)
 				{
 					//89-93
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots);
+					var index = i - NetItem.MiscEquipIndex.Item1;
 					player.TPlayer.miscEquips[index].netDefaults(this.inventory[i].NetId);
 
 					if (player.TPlayer.miscEquips[index].netID != 0)
@@ -274,13 +274,10 @@ namespace TShockAPI
 						player.TPlayer.miscEquips[index].prefix = (byte)this.inventory[i].PrefixId;
 					}
 				}
-				else if (i <
-					NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots
-					+ NetItem.MiscDyeSlots)
+				else if (i < NetItem.MiscDyeIndex.Item2)
 				{
 					//93-98
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots
-						+ NetItem.MiscEquipSlots);
+					var index = i - NetItem.MiscDyeIndex.Item1;
 					player.TPlayer.miscDyes[index].netDefaults(this.inventory[i].NetId);
 
 					if (player.TPlayer.miscDyes[index].netID != 0)
@@ -289,13 +286,10 @@ namespace TShockAPI
 						player.TPlayer.miscDyes[index].prefix = (byte)this.inventory[i].PrefixId;
 					}
 				}
-				else if (i <
-					NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots +
-					NetItem.MiscDyeSlots + NetItem.PiggySlots)
+				else if (i < NetItem.PiggyIndex.Item2)
 				{
 					//98-138
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots
-						+ NetItem.MiscEquipSlots + NetItem.MiscDyeSlots);
+					var index = i - NetItem.PiggyIndex.Item1;
 					player.TPlayer.bank.item[index].netDefaults(this.inventory[i].NetId);
 
 					if (player.TPlayer.bank.item[index].netID != 0)
@@ -304,12 +298,10 @@ namespace TShockAPI
 						player.TPlayer.bank.item[index].prefix = (byte)this.inventory[i].PrefixId;
 					}
 				}
-				else if (i <
-					NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots +
-					NetItem.MiscDyeSlots + NetItem.PiggySlots + NetItem.SafeSlots)
+				else if (i < NetItem.SafeIndex.Item2)
 				{
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots
-						+ NetItem.MiscEquipSlots + NetItem.MiscDyeSlots + NetItem.PiggySlots);
+					//138-178
+					var index = i - NetItem.SafeIndex.Item1;
 					player.TPlayer.bank2.item[index].netDefaults(this.inventory[i].NetId);
 
 					if (player.TPlayer.bank2.item[index].netID != 0)
@@ -318,22 +310,10 @@ namespace TShockAPI
 						player.TPlayer.bank2.item[index].prefix = (byte)this.inventory[i].PrefixId;
 					}
 				}
-				else if (i <
-				   NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots +
-				   NetItem.MiscDyeSlots + NetItem.PiggySlots + NetItem.SafeSlots + NetItem.ForgeSlots)
+				else if (i < NetItem.TrashIndex.Item2)
 				{
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots
-						+ NetItem.MiscEquipSlots + NetItem.MiscDyeSlots + NetItem.PiggySlots + NetItem.SafeSlots);
-					player.TPlayer.bank3.item[index].netDefaults(this.inventory[i].NetId);
-
-					if (player.TPlayer.bank3.item[index].netID != 0)
-					{
-						player.TPlayer.bank3.item[index].stack = this.inventory[i].Stack;
-						player.TPlayer.bank3.item[index].prefix = (byte)this.inventory[i].PrefixId;
-					}
-				}
-				else
-				{
+					//179-219
+					var index = i - NetItem.TrashIndex.Item1;
 					player.TPlayer.trashItem.netDefaults(this.inventory[i].NetId);
 
 					if (player.TPlayer.trashItem.netID != 0)
@@ -341,6 +321,19 @@ namespace TShockAPI
 						player.TPlayer.trashItem.stack = this.inventory[i].Stack;
 						player.TPlayer.trashItem.prefix = (byte)this.inventory[i].PrefixId;
 					}
+				}
+				else
+				{
+					//220
+					var index = i - NetItem.ForgeIndex.Item1;
+					player.TPlayer.bank3.item[index].netDefaults(this.inventory[i].NetId);
+
+					if (player.TPlayer.bank3.item[index].netID != 0)
+					{
+						player.TPlayer.bank3.item[index].stack = this.inventory[i].Stack;
+						player.TPlayer.bank3.item[index].Prefix((byte)this.inventory[i].PrefixId);
+					}
+					
 				}
 			}
 
@@ -380,13 +373,13 @@ namespace TShockAPI
 				NetMessage.SendData(5, -1, -1, Main.player[player.Index].bank2.item[k].name, player.Index, slot, (float)Main.player[player.Index].bank2.item[k].prefix);
 				slot++;
 			}
+			NetMessage.SendData(5, -1, -1, Main.player[player.Index].trashItem.name, player.Index, slot++, (float)Main.player[player.Index].trashItem.prefix);
 			for (int k = 0; k < NetItem.ForgeSlots; k++)
 			{
 				NetMessage.SendData(5, -1, -1, Main.player[player.Index].bank3.item[k].name, player.Index, slot, (float)Main.player[player.Index].bank3.item[k].prefix);
 				slot++;
 			}
 
-			NetMessage.SendData(5, -1, -1, Main.player[player.Index].trashItem.name, player.Index, slot, (float)Main.player[player.Index].trashItem.prefix);
 
 			NetMessage.SendData(4, -1, -1, player.Name, player.Index, 0f, 0f, 0f, 0);
 			NetMessage.SendData(42, -1, -1, "", player.Index, 0f, 0f, 0f, 0);
@@ -428,13 +421,14 @@ namespace TShockAPI
 				NetMessage.SendData(5, player.Index, -1, Main.player[player.Index].bank2.item[k].name, player.Index, slot, (float)Main.player[player.Index].bank2.item[k].prefix);
 				slot++;
 			}
+			NetMessage.SendData(5, player.Index, -1, Main.player[player.Index].trashItem.name, player.Index, slot++, (float)Main.player[player.Index].trashItem.prefix);
 			for (int k = 0; k < NetItem.ForgeSlots; k++)
 			{
 				NetMessage.SendData(5, player.Index, -1, Main.player[player.Index].bank3.item[k].name, player.Index, slot, (float)Main.player[player.Index].bank3.item[k].prefix);
 				slot++;
 			}
 
-			NetMessage.SendData(5, player.Index, -1, Main.player[player.Index].trashItem.name, player.Index, slot, (float)Main.player[player.Index].trashItem.prefix);
+			
 
 			NetMessage.SendData(4, player.Index, -1, player.Name, player.Index, 0f, 0f, 0f, 0);
 			NetMessage.SendData(42, player.Index, -1, "", player.Index, 0f, 0f, 0f, 0);

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1951,6 +1951,7 @@ namespace TShockAPI
 		/// <returns>bool - True if the player has a hacked inventory.</returns>
 		public static bool HackedInventory(TSPlayer player)
 		{
+			//TODO:  Update this to the new logic in PlayerData.
 			bool check = false;
 
 			Item[] inventory = player.TPlayer.inventory;
@@ -1962,10 +1963,9 @@ namespace TShockAPI
 			Item[] safe = player.TPlayer.bank2.item;
 			Item[] forge = player.TPlayer.bank3.item;
 			Item trash = player.TPlayer.trashItem;
-
 			for (int i = 0; i < NetItem.MaxInventory; i++)
 			{
-				if (i < NetItem.InventorySlots)
+				if (i < NetItem.InventoryIndex.Item2)
 				{
 					//0-58
 					Item item = new Item();
@@ -1983,11 +1983,11 @@ namespace TShockAPI
 						}
 					}
 				}
-				else if (i < NetItem.InventorySlots + NetItem.ArmorSlots)
+				else if (i < NetItem.ArmorIndex.Item2)
 				{
 					//59-78
+					var index = i - NetItem.ArmorIndex.Item1;
 					Item item = new Item();
-					var index = i - NetItem.InventorySlots;
 					if (armor[index] != null && armor[index].netID != 0)
 					{
 						item.netDefaults(armor[index].netID);
@@ -2002,11 +2002,11 @@ namespace TShockAPI
 						}
 					}
 				}
-				else if (i < NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots)
+				else if (i < NetItem.DyeIndex.Item2)
 				{
 					//79-88
+					var index = i - NetItem.DyeIndex.Item1;
 					Item item = new Item();
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots);
 					if (dye[index] != null && dye[index].netID != 0)
 					{
 						item.netDefaults(dye[index].netID);
@@ -2021,12 +2021,11 @@ namespace TShockAPI
 						}
 					}
 				}
-				else if (i <
-					NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots)
+				else if (i < NetItem.MiscEquipIndex.Item2)
 				{
 					//89-93
+					var index = i - NetItem.MiscEquipIndex.Item1;
 					Item item = new Item();
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots);
 					if (miscEquips[index] != null && miscEquips[index].netID != 0)
 					{
 						item.netDefaults(miscEquips[index].netID);
@@ -2041,14 +2040,11 @@ namespace TShockAPI
 						}
 					}
 				}
-				else if (i <
-					NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots
-					+ NetItem.MiscDyeSlots)
+				else if (i < NetItem.MiscDyeIndex.Item2)
 				{
 					//93-98
+					var index = i - NetItem.MiscDyeIndex.Item1;
 					Item item = new Item();
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots
-						+ NetItem.MiscEquipSlots);
 					if (miscDyes[index] != null && miscDyes[index].netID != 0)
 					{
 						item.netDefaults(miscDyes[index].netID);
@@ -2063,14 +2059,11 @@ namespace TShockAPI
 						}
 					}
 				}
-				else if (i <
-				   NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots +
-				   NetItem.MiscDyeSlots + NetItem.PiggySlots)
+				else if (i < NetItem.PiggyIndex.Item2)
 				{
 					//98-138
+					var index = i - NetItem.PiggyIndex.Item1;
 					Item item = new Item();
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots
-						+ NetItem.MiscEquipSlots + NetItem.MiscDyeSlots);
 					if (piggy[index] != null && piggy[index].netID != 0)
 					{
 						item.netDefaults(piggy[index].netID);
@@ -2086,14 +2079,11 @@ namespace TShockAPI
 						}
 					}
 				}
-				else if (i <
-					NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots +
-					NetItem.MiscDyeSlots + NetItem.PiggySlots + NetItem.SafeSlots)
+				else if (i < NetItem.SafeIndex.Item2)
 				{
 					//138-178
+					var index = i - NetItem.SafeIndex.Item1;
 					Item item = new Item();
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots
-						+ NetItem.MiscEquipSlots + NetItem.MiscDyeSlots + NetItem.PiggySlots);
 					if (safe[index] != null && safe[index].netID != 0)
 					{
 						item.netDefaults(safe[index].netID);
@@ -2109,31 +2099,9 @@ namespace TShockAPI
 						}
 					}
 				}
-				else if (i <
-					NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots + NetItem.MiscEquipSlots +
-					NetItem.MiscDyeSlots + NetItem.PiggySlots + NetItem.SafeSlots + NetItem.ForgeSlots)
+				else if (i < NetItem.TrashIndex.Item2)
 				{
 					//179-219
-					Item item = new Item();
-					var index = i - (NetItem.InventorySlots + NetItem.ArmorSlots + NetItem.DyeSlots
-						+ NetItem.MiscEquipSlots + NetItem.MiscDyeSlots + NetItem.PiggySlots + NetItem.SafeSlots);
-					if (forge[index] != null && forge[index].netID != 0)
-					{
-						item.netDefaults(forge[index].netID);
-						item.Prefix(forge[index].prefix);
-						item.AffixName();
-
-						if (forge[index].stack > item.maxStack)
-						{
-							check = true;
-							player.SendMessage(
-								String.Format("Stack cheat detected. Remove Defender's Forge item {0} ({1}) and then rejoin", item.name, forge[index].stack),
-								Color.Cyan);
-						}
-					}
-				}
-				else
-				{
 					Item item = new Item();
 					if (trash != null && trash.netID != 0)
 					{
@@ -2149,6 +2117,27 @@ namespace TShockAPI
 								Color.Cyan);
 						}
 					}
+				}
+				else
+				{
+					//220
+					var index = i - NetItem.ForgeIndex.Item1;
+					Item item = new Item();
+					if (forge[index] != null && forge[index].netID != 0)
+					{
+						item.netDefaults(forge[index].netID);
+						item.Prefix(forge[index].prefix);
+						item.AffixName();
+
+						if (forge[index].stack > item.maxStack)
+						{
+							check = true;
+							player.SendMessage(
+								String.Format("Stack cheat detected. Remove Defender's Forge item {0} ({1}) and then rejoin", item.name, forge[index].stack),
+								Color.Cyan);
+						}
+					}
+
 				}
 			}
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1951,7 +1951,6 @@ namespace TShockAPI
 		/// <returns>bool - True if the player has a hacked inventory.</returns>
 		public static bool HackedInventory(TSPlayer player)
 		{
-			//TODO:  Update this to the new logic in PlayerData.
 			bool check = false;
 
 			Item[] inventory = player.TPlayer.inventory;


### PR DESCRIPTION
This PR fixes #1349.

__Issue:__  
The issue is that unbeknownst to us, and for whatever reason, the trashcan slots are before the forges slots.  I assume the trash can was added to SSC before the forge was, and as such was cemented in place.

__Resolution:__  
Resolution is to read the trashcan/send the trashcan/deal with the trashcan before the forge slots.

__Extraneous:__  
I refactored some more uses of the NetItem statics to use the Tuples in order to simplify the code and become more readable.