### PR TITLE
Players shouldn't be able to change their groups through /user commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * API: Added TSPlayer.Logout() (@ProfessorXZ)
 * Fixed connections after max slot is reached (@DeathCradle)
 * Fixed server crashes caused by client disconnections when attempting to read closed sockets (@Enerdy)
+* Players are no longer able to change their own group (@ProfessorXZ)
 
 ## TShock 4.3.21
 * Compatibility with Terraria 1.3.4.3 (@Patrikkk, @Zaicon).

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -1013,6 +1013,12 @@ namespace TShockAPI
 				return;
 			}
 
+			if (!args.Player.IsLoggedIn && args.Player.RealPlayer)
+			{
+				args.Player.SendErrorMessage("You are not logged in.");
+				return;
+			}
+
 			string subcmd = args.Parameters[0];
 
 			// Add requires a username, password, and a group specified.
@@ -1109,7 +1115,7 @@ namespace TShockAPI
 
 				try
 				{
-					if (user.Name == args.Player.User?.Name)
+					if (user.Name == args.Player.User.Name)
 					{
 						args.Player.SendErrorMessage("You cannot change your own group.");
 						return;

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -1109,6 +1109,12 @@ namespace TShockAPI
 
 				try
 				{
+					if (user.Name == args.Player.User?.Name)
+					{
+						args.Player.SendErrorMessage("You cannot change your own group.");
+						return;
+					}
+
 					TShock.Users.SetUserGroup(user, args.Parameters[2]);
 					TShock.Log.ConsoleInfo(args.Player.Name + " changed account " + user.Name + " to group " + args.Parameters[2] + ".");
 					args.Player.SendSuccessMessage("Account " + user.Name + " has been changed to group " + args.Parameters[2] + "!");


### PR DESCRIPTION
Even though the `tshock.superadmin.user` permission is meant for superadmins only there are still people who do not follow that "rule". This lets mods give themselves superadmin powers, which is "BAD BAD". The check should be there nevertheless as I see no reason why you would let anyone change their own permissions.