### PR TITLE
Document and fix the fishing quest count glitch in SSC.

### DIFF
--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -438,8 +438,17 @@ namespace TShockAPI
 			{
 				player.TPlayer.buffType[k] = 0;
 			}
+
+			/*
+			 * The following packets are sent twice because the server will not send a packet to a client
+			 * if they have not spawned yet if the remoteclient is -1
+			 * This is for when players login via uuid or serverpassword instead of via
+			 * the login command.
+			 */
 			NetMessage.SendData(50, -1, -1, "", player.Index, 0f, 0f, 0f, 0);
 			NetMessage.SendData(50, player.Index, -1, "", player.Index, 0f, 0f, 0f, 0);
+
+			NetMessage.SendData(76, player.Index, -1, "", player.Index);
 			NetMessage.SendData(76, -1, -1, "", player.Index);
 
 			NetMessage.SendData(39, player.Index, -1, "", 400);


### PR DESCRIPTION
Problem:
We were sending the correct packet in a state where the client was half connected.  The terraria handshake was not yet complete, and the netmessage protocol says to drop a packet to players not fully connected if the remoteclient is -1. 

Remoteclient == -1 means send this packet to everyone.  Thus, when we sent the fishing quest packet to all players, the actual player it was for never got sent it.  By changing the remoteclient to the specific player, the packet will always go out.  I do not believe we need to send this packet to everyone, but since we already were I left it in.

Solution:
Change the remoteclient in RestoreCharacter in PlayerData.cs to the player in question as we did with every other packet.