### PR TITLE
Add banning user and ban date fields to ban info and list endpoints

### DIFF
--- a/TShockAPI/Rest/RestManager.cs
+++ b/TShockAPI/Rest/RestManager.cs
@@ -726,7 +726,7 @@ namespace TShockAPI
 					{
 						{"name", null == ban.Name ? "" : ban.Name},
 						{"ip", null == ban.IP ? "" : ban.IP},
-            {"banning_user", null == ban.BanningUser ? "" : ban.BanningUser},
+            					{"banning_user", null == ban.BanningUser ? "" : ban.BanningUser},
 						{"date", null == ban.BanDateTime ? "" : ban.BanDateTime.Value.ToString()},
 						{"reason", null == ban.Reason ? "" : ban.Reason},
 					}

--- a/TShockAPI/Rest/RestManager.cs
+++ b/TShockAPI/Rest/RestManager.cs
@@ -706,6 +706,8 @@ namespace TShockAPI
 			return new RestObject() {
 				{"name", null == ban.Name ? "" : ban.Name},
 				{"ip", null == ban.IP ? "" : ban.IP},
+				{"banning_user", null == ban.BanningUser ? "" : ban.BanningUser},
+				{"date", null == ban.BanDateTime ? "" : ban.BanDateTime.Value.ToString()},
 				{"reason", null == ban.Reason ? "" : ban.Reason},
 			};
 		}
@@ -724,6 +726,8 @@ namespace TShockAPI
 					{
 						{"name", null == ban.Name ? "" : ban.Name},
 						{"ip", null == ban.IP ? "" : ban.IP},
+            {"banning_user", null == ban.BanningUser ? "" : ban.BanningUser},
+						{"date", null == ban.BanDateTime ? "" : ban.BanDateTime.Value.ToString()},
 						{"reason", null == ban.Reason ? "" : ban.Reason},
 					}
 				);
@@ -735,7 +739,7 @@ namespace TShockAPI
 		#endregion
 
 		#region Rest World Methods
-		
+
 		[Route("/v2/world/autosave/state/{state}")]
 		[Permission(RestPermissions.restcfg)]
 		[Verb("state", "The status for autosave.", typeof(bool))]


### PR DESCRIPTION
Adds: `Ban.BanningUser` (string) and the date when the ban occurred `Ban.BanDateTime` (string)

Maybe return null instead of empty strings?