### PR TITLE
Add Localization support

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -2544,7 +2544,7 @@ namespace TShockAPI
 					break;
 				}
 				if (npc.FullName.ToLowerInvariant().StartsWith(npcStr.ToLowerInvariant()) ||
-				    englishName.StartsWith(npcStr, StringComparison.InvariantCultureIgnoreCase))
+				    englishName?.StartsWith(npcStr, StringComparison.InvariantCultureIgnoreCase) == true)
 					matches.Add(npc);
 			}
 

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -34,6 +34,7 @@ using TShockAPI.Hooks;
 using Terraria.GameContent.Events;
 using Microsoft.Xna.Framework;
 using OTAPI.Tile;
+using TShockAPI.Localization;
 
 namespace TShockAPI
 {
@@ -2534,12 +2535,16 @@ namespace TShockAPI
 			var matches = new List<NPC>();
 			foreach (var npc in Main.npc.Where(npc => npc.active))
 			{
-				if (string.Equals(npc.FullName, npcStr, StringComparison.CurrentCultureIgnoreCase))
+				var englishName = EnglishLanguage.GetNpcNameById(npc.netID);
+
+				if (string.Equals(npc.FullName, npcStr, StringComparison.InvariantCultureIgnoreCase) ||
+				    string.Equals(englishName, npcStr, StringComparison.InvariantCultureIgnoreCase))
 				{
 					matches = new List<NPC> { npc };
 					break;
 				}
-				if (npc.FullName.ToLower().StartsWith(npcStr.ToLower()))
+				if (npc.FullName.ToLowerInvariant().StartsWith(npcStr.ToLowerInvariant()) ||
+				    englishName.StartsWith(npcStr, StringComparison.InvariantCultureIgnoreCase))
 					matches.Add(npc);
 			}
 
@@ -3207,7 +3212,7 @@ namespace TShockAPI
 						}
 						else
 						{
-							TShock.Itembans.AddNewBan(items[0].Name);
+							TShock.Itembans.AddNewBan(EnglishLanguage.GetItemNameById(items[0].type));
 							args.Player.SendSuccessMessage("Banned " + items[0].Name + ".");
 						}
 					}
@@ -3239,7 +3244,7 @@ namespace TShockAPI
 								return;
 							}
 
-							ItemBan ban = TShock.Itembans.GetItemBanByName(items[0].Name);
+							ItemBan ban = TShock.Itembans.GetItemBanByName(EnglishLanguage.GetItemNameById(items[0].type));
 							if (ban == null)
 							{
 								args.Player.SendErrorMessage("{0} is not banned.", items[0].Name);
@@ -3247,7 +3252,7 @@ namespace TShockAPI
 							}
 							if (!ban.AllowedGroups.Contains(args.Parameters[2]))
 							{
-								TShock.Itembans.AllowGroup(items[0].Name, args.Parameters[2]);
+								TShock.Itembans.AllowGroup(EnglishLanguage.GetItemNameById(items[0].type), args.Parameters[2]);
 								args.Player.SendSuccessMessage("{0} has been allowed to use {1}.", args.Parameters[2], items[0].Name);
 							}
 							else
@@ -3278,7 +3283,7 @@ namespace TShockAPI
 						}
 						else
 						{
-							TShock.Itembans.RemoveBan(items[0].Name);
+							TShock.Itembans.RemoveBan(EnglishLanguage.GetItemNameById(items[0].type));
 							args.Player.SendSuccessMessage("Unbanned " + items[0].Name + ".");
 						}
 					}
@@ -3310,7 +3315,7 @@ namespace TShockAPI
 								return;
 							}
 
-							ItemBan ban = TShock.Itembans.GetItemBanByName(items[0].Name);
+							ItemBan ban = TShock.Itembans.GetItemBanByName(EnglishLanguage.GetItemNameById(items[0].type));
 							if (ban == null)
 							{
 								args.Player.SendErrorMessage("{0} is not banned.", items[0].Name);
@@ -3318,7 +3323,7 @@ namespace TShockAPI
 							}
 							if (ban.AllowedGroups.Contains(args.Parameters[2]))
 							{
-								TShock.Itembans.RemoveGroup(items[0].Name, args.Parameters[2]);
+								TShock.Itembans.RemoveGroup(EnglishLanguage.GetItemNameById(items[0].type), args.Parameters[2]);
 								args.Player.SendSuccessMessage("{0} has been disallowed to use {1}.", args.Parameters[2], items[0].Name);
 							}
 							else
@@ -5292,7 +5297,7 @@ namespace TShockAPI
 				if (itemAmount == 0 || itemAmount > item.maxStack)
 					itemAmount = item.maxStack;
 
-				if (args.Player.GiveItemCheck(item.type, item.Name, item.width, item.height, itemAmount, prefixId))
+				if (args.Player.GiveItemCheck(item.type, EnglishLanguage.GetItemNameById(item.type), item.width, item.height, itemAmount, prefixId))
 				{
 					item.prefix = (byte)prefixId;
 					args.Player.SendSuccessMessage("Gave {0} {1}(s).", itemAmount, item.AffixName());
@@ -5431,7 +5436,7 @@ namespace TShockAPI
 						{
 							if (itemAmount == 0 || itemAmount > item.maxStack)
 								itemAmount = item.maxStack;
-							if (plr.GiveItemCheck(item.type, item.Name, item.width, item.height, itemAmount, prefix))
+							if (plr.GiveItemCheck(item.type, EnglishLanguage.GetItemNameById(item.type), item.width, item.height, itemAmount, prefix))
 							{
 								args.Player.SendSuccessMessage(string.Format("Gave {0} {1} {2}(s).", plr.Name, itemAmount, item.Name));
 								plr.SendSuccessMessage(string.Format("{0} gave you {1} {2}(s).", args.Player.Name, itemAmount, item.Name));

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -35,6 +35,7 @@ using Terraria.GameContent.Tile_Entities;
 using Terraria.Localization;
 using Microsoft.Xna.Framework;
 using OTAPI.Tile;
+using TShockAPI.Localization;
 
 namespace TShockAPI
 {
@@ -3330,7 +3331,7 @@ namespace TShockAPI
 
 			Item item = new Item();
 			item.netDefaults(type);
-			if (stacks > item.maxStack || TShock.Itembans.ItemIsBanned(item.Name, args.Player))
+			if (stacks > item.maxStack || TShock.Itembans.ItemIsBanned(EnglishLanguage.GetItemNameById(item.type), args.Player))
 			{
 				return false;
 			}
@@ -3510,7 +3511,7 @@ namespace TShockAPI
 
 			Item item = new Item();
 			item.netDefaults(type);
-			if ((stacks > item.maxStack || stacks <= 0) || (TShock.Itembans.ItemIsBanned(item.Name, args.Player) && !args.Player.HasPermission(Permissions.allowdroppingbanneditems)))
+			if ((stacks > item.maxStack || stacks <= 0) || (TShock.Itembans.ItemIsBanned(EnglishLanguage.GetItemNameById(item.type), args.Player) && !args.Player.HasPermission(Permissions.allowdroppingbanneditems)))
 			{
 				args.Player.SendData(PacketTypes.ItemDrop, "", id);
 				return true;
@@ -4419,7 +4420,7 @@ namespace TShockAPI
 			{
 				return true;
 			}
-			
+
 			if (!args.Player.HasPermission(Permissions.startdd2))
 			{
 				args.Player.SendErrorMessage("You don't have permission to start the Old One's Army event.");

--- a/TShockAPI/Localization/EnglishLanguage.cs
+++ b/TShockAPI/Localization/EnglishLanguage.cs
@@ -25,8 +25,10 @@ namespace TShockAPI.Localization
 
 			try
 			{
-				if(!skip)
+				if (!skip)
+				{
 					LanguageManager.Instance.SetLanguage(GameCulture.English);
+				}
 
 				for (var i = -48; i < Main.maxItemTypes; i++)
 				{
@@ -46,8 +48,10 @@ namespace TShockAPI.Localization
 			}
 			finally
 			{
-				if(!skip)
+				if (!skip)
+				{
 					LanguageManager.Instance.SetLanguage(culture);
+				}
 			}
 		}
 
@@ -62,7 +66,7 @@ namespace TShockAPI.Localization
 			if (ItemNames.TryGetValue(id, out itemName))
 				return itemName;
 
-			return string.Empty;
+			return null;
 		}
 
 		/// <summary>
@@ -76,7 +80,7 @@ namespace TShockAPI.Localization
 			if (NpcNames.TryGetValue(id, out npcName))
 				return npcName;
 
-			return string.Empty;
+			return null;
 		}
 
 		/// <summary>
@@ -90,7 +94,7 @@ namespace TShockAPI.Localization
 			if (Prefixs.TryGetValue(id, out prefix))
 				return prefix;
 
-			return string.Empty;
+			return null;
 		}
 	}
 }

--- a/TShockAPI/Localization/EnglishLanguage.cs
+++ b/TShockAPI/Localization/EnglishLanguage.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Terraria;
+using Terraria.Localization;
+
+namespace TShockAPI.Localization
+{
+	/// <summary>
+	/// Provides a series of methods that give English texts
+	/// </summary>
+	public static class EnglishLanguage
+	{
+		private static readonly Dictionary<int, string> ItemNames = new Dictionary<int, string>();
+
+		private static readonly Dictionary<int, string> NpcNames = new Dictionary<int, string>();
+
+		private static readonly Dictionary<int, string> Prefixs = new Dictionary<int, string>();
+
+		internal static void Initialize()
+		{
+			var culture = Language.ActiveCulture;
+
+			var skip = culture == GameCulture.English;
+
+			try
+			{
+				if(!skip)
+					LanguageManager.Instance.SetLanguage(GameCulture.English);
+
+				for (var i = -48; i < Main.maxItemTypes; i++)
+				{
+					ItemNames.Add(i, Lang.GetItemNameValue(i));
+				}
+
+				for (var i = -17; i < Main.maxNPCTypes; i++)
+				{
+					NpcNames.Add(i, Lang.GetNPCNameValue(i));
+				}
+
+				foreach (var field in typeof(Main).Assembly.GetType("Terraria.ID.PrefixID")
+							.GetFields().Where(f => !f.Name.Equals("Count", StringComparison.Ordinal)))
+				{
+					Prefixs.Add((int) field.GetValue(null), field.Name);
+				}
+			}
+			finally
+			{
+				if(!skip)
+					LanguageManager.Instance.SetLanguage(culture);
+			}
+		}
+
+		/// <summary>
+		/// Get the english name of an item
+		/// </summary>
+		/// <param name="id">Id of the item</param>
+		/// <returns>Item name in English</returns>
+		public static string GetItemNameById(int id)
+		{
+			string itemName;
+			if (ItemNames.TryGetValue(id, out itemName))
+				return itemName;
+
+			return string.Empty;
+		}
+
+		/// <summary>
+		/// Get the english name of a npc
+		/// </summary>
+		/// <param name="id">Id of the npc</param>
+		/// <returns>Npc name in English</returns>
+		public static string GetNpcNameById(int id)
+		{
+			string npcName;
+			if (NpcNames.TryGetValue(id, out npcName))
+				return npcName;
+
+			return string.Empty;
+		}
+
+		/// <summary>
+		/// Get prefix in English
+		/// </summary>
+		/// <param name="id">Prefix Id</param>
+		/// <returns>Prefix in English</returns>
+		public static string GetPrefixById(int id)
+		{
+			string prefix;
+			if (Prefixs.TryGetValue(id, out prefix))
+				return prefix;
+
+			return string.Empty;
+		}
+	}
+}

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -43,6 +43,7 @@ using Terraria.Utilities;
 using Microsoft.Xna.Framework;
 using TShockAPI.Sockets;
 using TShockAPI.CLI;
+using TShockAPI.Localization;
 
 namespace TShockAPI
 {
@@ -356,6 +357,8 @@ namespace TShockAPI
 				GetDataHandlers.InitGetDataHandler();
 				Commands.InitCommands();
 
+				EnglishLanguage.Initialize();
+
 				if (Config.RestApiEnabled)
 					RestApi.Start();
 
@@ -620,7 +623,7 @@ namespace TShockAPI
 			string path = null;
 
 			//Generic method for doing a path sanity check
-			Action<string> pathChecker = (p) => 
+			Action<string> pathChecker = (p) =>
 			{
 				if (!string.IsNullOrWhiteSpace(p) && p.IndexOfAny(Path.GetInvalidPathChars()) == -1)
 				{
@@ -733,7 +736,7 @@ namespace TShockAPI
 				.AddFlag("--no-restart", () => NoRestart = true);
 
 			CliParser.ParseFromSource(parms);
-			
+
 			/*"-connperip": Todo - Requires an OTAPI modification
 			{
 				int limit;
@@ -1111,7 +1114,7 @@ namespace TShockAPI
 						// Please don't remove this for the time being; without it, players wearing banned equipment will only get debuffed once
 						foreach (Item item in player.TPlayer.armor)
 						{
-							if (Itembans.ItemIsBanned(item.Name, player))
+							if (Itembans.ItemIsBanned(EnglishLanguage.GetItemNameById(item.type), player))
 							{
 								player.SetBuff(BuffID.Frozen, 330, true);
 								player.SetBuff(BuffID.Stoned, 330, true);
@@ -1124,7 +1127,7 @@ namespace TShockAPI
 						}
 						foreach (Item item in player.TPlayer.dye)
 						{
-							if (Itembans.ItemIsBanned(item.Name, player))
+							if (Itembans.ItemIsBanned(EnglishLanguage.GetItemNameById(item.type), player))
 							{
 								player.SetBuff(BuffID.Frozen, 330, true);
 								player.SetBuff(BuffID.Stoned, 330, true);
@@ -1137,7 +1140,7 @@ namespace TShockAPI
 						}
 						foreach (Item item in player.TPlayer.miscEquips)
 						{
-							if (Itembans.ItemIsBanned(item.Name, player))
+							if (Itembans.ItemIsBanned(EnglishLanguage.GetItemNameById(item.type), player))
 							{
 								player.SetBuff(BuffID.Frozen, 330, true);
 								player.SetBuff(BuffID.Stoned, 330, true);
@@ -1150,7 +1153,7 @@ namespace TShockAPI
 						}
 						foreach (Item item in player.TPlayer.miscDyes)
 						{
-							if (Itembans.ItemIsBanned(item.Name, player))
+							if (Itembans.ItemIsBanned(EnglishLanguage.GetItemNameById(item.type), player))
 							{
 								player.SetBuff(BuffID.Frozen, 330, true);
 								player.SetBuff(BuffID.Stoned, 330, true);

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Hooks\PlayerHooks.cs" />
     <Compile Include="Hooks\RegionHooks.cs" />
     <Compile Include="ILog.cs" />
+    <Compile Include="Localization\EnglishLanguage.cs" />
     <Compile Include="NetItem.cs" />
     <Compile Include="PlayerData.cs" />
     <Compile Include="Sockets\LinuxTcpSocket.cs" />

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -32,6 +32,7 @@ using Terraria.Utilities;
 using TShockAPI.DB;
 using BCrypt.Net;
 using Microsoft.Xna.Framework;
+using TShockAPI.Localization;
 
 namespace TShockAPI
 {
@@ -344,16 +345,27 @@ namespace TShockAPI
 		{
 			var found = new List<Item>();
 			Item item = new Item();
-			string nameLower = name.ToLower();
+			string nameLower = name.ToLowerInvariant();
 			for (int i = -48; i < Main.maxItemTypes; i++)
 			{
 				item.netDefaults(i);
-				if (String.IsNullOrWhiteSpace(item.Name))
-					continue;
-				if (item.Name.ToLower() == nameLower)
-					return new List<Item> { item };
-				if (item.Name.ToLower().StartsWith(nameLower))
-					found.Add(item.Clone());
+				if (!String.IsNullOrWhiteSpace(item.Name))
+				{
+					if (item.Name.ToLowerInvariant() == nameLower)
+						return new List<Item> { item };
+					if (item.Name.ToLowerInvariant().StartsWith(nameLower))
+						found.Add(item.Clone());
+				}
+
+				string englishName = EnglishLanguage.GetItemNameById(i).ToLowerInvariant();
+				if (!String.IsNullOrWhiteSpace(englishName))
+				{
+					if (englishName == nameLower)
+						return new List<Item> { item };
+						return new List<Item> { item };
+					if (englishName.StartsWith(nameLower))
+						found.Add(item.Clone());
+				}
 			}
 			return found;
 		}
@@ -416,13 +428,17 @@ namespace TShockAPI
 		{
 			var found = new List<NPC>();
 			NPC npc = new NPC();
-			string nameLower = name.ToLower();
+			string nameLower = name.ToLowerInvariant();
 			for (int i = -17; i < Main.maxNPCTypes; i++)
 			{
+				string englishName = EnglishLanguage.GetNpcNameById(i).ToLowerInvariant();
+
 				npc.SetDefaults(i);
-				if (npc.FullName.ToLower() == nameLower || npc.TypeName.ToLower() == nameLower)
+				if (npc.FullName.ToLowerInvariant() == nameLower || npc.TypeName.ToLowerInvariant() == nameLower
+					|| nameLower == englishName)
 					return new List<NPC> { npc };
-				if (npc.FullName.ToLower().StartsWith(nameLower) || npc.TypeName.ToLower().StartsWith(nameLower))
+				if (npc.FullName.ToLowerInvariant().StartsWith(nameLower) || npc.TypeName.ToLowerInvariant().StartsWith(nameLower)
+					|| englishName.StartsWith(nameLower))
 					found.Add((NPC)npc.Clone());
 			}
 			return found;
@@ -492,15 +508,16 @@ namespace TShockAPI
 		{
 			Item item = new Item();
 			item.SetDefaults(0);
-			string lowerName = name.ToLower();
+			string lowerName = name.ToLowerInvariant();
 			var found = new List<int>();
 			for (int i = FirstItemPrefix; i <= LastItemPrefix; i++)
 			{
 				item.prefix = (byte)i;
-				string prefixName = item.AffixName().Trim().ToLower();
-				if (prefixName == lowerName)
+				string prefixName = item.AffixName().Trim().ToLowerInvariant();
+				string englishName = EnglishLanguage.GetPrefixById(i).ToLowerInvariant();
+				if (prefixName == lowerName || englishName == lowerName)
 					return new List<int>() { i };
-				else if (prefixName.StartsWith(lowerName)) // Partial match
+				else if (prefixName.StartsWith(lowerName) || englishName.StartsWith(lowerName)) // Partial match
 					found.Add(i);
 			}
 			return found;

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -437,7 +437,7 @@ namespace TShockAPI
 					|| nameLower == englishName)
 					return new List<NPC> { npc };
 				if (npc.FullName.ToLowerInvariant().StartsWith(nameLower) || npc.TypeName.ToLowerInvariant().StartsWith(nameLower)
-					|| englishName.StartsWith(nameLower))
+					|| englishName?.StartsWith(nameLower) == true)
 					found.Add((NPC)npc.Clone());
 			}
 			return found;
@@ -516,7 +516,7 @@ namespace TShockAPI
 				string englishName = EnglishLanguage.GetPrefixById(i).ToLowerInvariant();
 				if (prefixName == lowerName || englishName == lowerName)
 					return new List<int>() { i };
-				else if (prefixName.StartsWith(lowerName) || englishName.StartsWith(lowerName)) // Partial match
+				else if (prefixName.StartsWith(lowerName) || englishName?.StartsWith(lowerName) == true) // Partial match
 					found.Add(i);
 			}
 			return found;

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -358,10 +358,9 @@ namespace TShockAPI
 				}
 
 				string englishName = EnglishLanguage.GetItemNameById(i).ToLowerInvariant();
-				if (!String.IsNullOrWhiteSpace(englishName))
+				if (!String.IsNullOrEmpty(englishName))
 				{
 					if (englishName == nameLower)
-						return new List<Item> { item };
 						return new List<Item> { item };
 					if (englishName.StartsWith(nameLower))
 						found.Add(item.Clone());


### PR DESCRIPTION
* Add EnglishLanguage type to store English texts
* Itemban database now store English item name
* Command `/i` `/give` `/sm` `/tpnpc` can use both English and current language input
---
Currently some plugins need English item name, npc name or prefix etc.
Also, Itemban uses item name to identify banned items. If server owners use latest TShock version with different language from English, all itemban data will be invalid because they were store in English.

This commit will solve the problem by adding a type called `EnglishLanguage` which has methods providing English texts.
Now, Itemban uses English text, and `GetItemByName`, `GetNPCByName`, and`GetBuffByName` can handle user input in both English and other language.