### PR TITLE
Fix an itemban issue due to localization / Remove utf8 modification build process

### DIFF
--- a/TShockAPI/DB/ItemManager.cs
+++ b/TShockAPI/DB/ItemManager.cs
@@ -65,7 +65,7 @@ namespace TShockAPI.DB
 			try
 			{
 				database.Query("INSERT INTO ItemBans (ItemName, AllowedGroups) VALUES (@0, @1);",
-				               TShock.Utils.GetItemByName(itemname)[0].Name, "");
+				               itemname, "");
 				if (!ItemIsBanned(itemname, null))
 					ItemBans.Add(new ItemBan(itemname));
 			}
@@ -81,7 +81,7 @@ namespace TShockAPI.DB
 				return;
 			try
 			{
-				database.Query("DELETE FROM ItemBans WHERE ItemName=@0;", TShock.Utils.GetItemByName(itemname)[0].Name);
+				database.Query("DELETE FROM ItemBans WHERE ItemName=@0;", itemname);
 				ItemBans.Remove(new ItemBan(itemname));
 			}
 			catch (Exception ex)

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -879,7 +879,7 @@ namespace TShockAPI
 				(TShock.Itembans.ItemIsBanned(name, this) || !TShock.Config.AllowAllowedGroupsToSpawnBannedItems))
 					return false;
 
-			GiveItem(type,name,width,height,stack,prefix);
+			GiveItem(type, name, width, height, stack, prefix);
 			return true;
 		}
 

--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -148,13 +148,11 @@ def run_bootstrapper():
     mod_clientuuid_proc = subprocess.Popen(['xbuild', './TerrariaServerAPI/TShock.Modifications.ClientUUID/TShock.Modifications.ClientUUID.csproj', '/p:Configuration=' + build_config])
     mod_explosives_proc = subprocess.Popen(['xbuild', './TerrariaServerAPI/TShock.Modifications.Explosives/TShock.Modifications.Explosives.csproj', '/p:Configuration=' + build_config])
     mod_ssc_proc = subprocess.Popen(['xbuild', './TerrariaServerAPI/TShock.Modifications.SSC/TShock.Modifications.SSC.csproj', '/p:Configuration=' + build_config])
-    mod_utf8_proc = subprocess.Popen(['xbuild', './TerrariaServerAPI/TShock.Modifications.UnicodeInput/TShock.Modifications.UnicodeInput.csproj', '/p:Configuration=' + build_config])
     
     mod_bootstrapper_proc.wait()
     mod_clientuuid_proc.wait()
     mod_explosives_proc.wait()
     mod_ssc_proc.wait()
-    mod_utf8_proc.wait()
     
     if (mod_bootstrapper_proc.returncode != 0):
       raise CalledProcessError(mod_bootstrapper_proc.returncode)


### PR DESCRIPTION
```csharp
database.Query("INSERT INTO ItemBans (ItemName, AllowedGroups) VALUES (@0, @1);",
 				               TShock.Utils.GetItemByName(itemname)[0].Name, "");
```
This will give the localized name of an item, but we need English name of the item.