### PR TITLE
Fix an itemban issue due to localization

### DIFF
--- a/TShockAPI/DB/ItemManager.cs
+++ b/TShockAPI/DB/ItemManager.cs
@@ -65,7 +65,7 @@ namespace TShockAPI.DB
 			try
 			{
 				database.Query("INSERT INTO ItemBans (ItemName, AllowedGroups) VALUES (@0, @1);",
-				               TShock.Utils.GetItemByName(itemname)[0].Name, "");
+				               itemname, "");
 				if (!ItemIsBanned(itemname, null))
 					ItemBans.Add(new ItemBan(itemname));
 			}
@@ -81,7 +81,7 @@ namespace TShockAPI.DB
 				return;
 			try
 			{
-				database.Query("DELETE FROM ItemBans WHERE ItemName=@0;", TShock.Utils.GetItemByName(itemname)[0].Name);
+				database.Query("DELETE FROM ItemBans WHERE ItemName=@0;", itemname);
 				ItemBans.Remove(new ItemBan(itemname));
 			}
 			catch (Exception ex)

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -879,7 +879,7 @@ namespace TShockAPI
 				(TShock.Itembans.ItemIsBanned(name, this) || !TShock.Config.AllowAllowedGroupsToSpawnBannedItems))
 					return false;
 
-			GiveItem(type,name,width,height,stack,prefix);
+			GiveItem(type, name, width, height, stack, prefix);
 			return true;
 		}
 


### PR DESCRIPTION
```csharp
database.Query("INSERT INTO ItemBans (ItemName, AllowedGroups) VALUES (@0, @1);",
 				               TShock.Utils.GetItemByName(itemname)[0].Name, "");
```
This will give the localized name of an item, but we need English name of the item.