### PR TITLE
Increased /butcher damage to defence fixes issue #1447

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -5207,7 +5207,7 @@ namespace TShockAPI
 			{
 				if (Main.npc[i].active && ((npcId == 0 && !Main.npc[i].townNPC && Main.npc[i].netID != NPCID.TargetDummy) || Main.npc[i].netID == npcId))
 				{
-					TSPlayer.Server.StrikeNPC(i, (int)(Main.npc[i].life + (Main.npc[i].defense * 0.5)), 0, 0);
+					TSPlayer.Server.StrikeNPC(i, (int)(Main.npc[i].life + (Main.npc[i].defense * 0.6)), 0, 0);
 					kills++;
 				}
 			}


### PR DESCRIPTION
Please mind my ignorance with this fix, I don't understand how the number 0.5 was derived but changing it to 0.6 allows NPCs at later stages to be killed using the /butcher command.
I'm guessing after a certain stage the NPCs receive a defense buff ?